### PR TITLE
Fix #72: Crypto 3.0: New activation

### DIFF
--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/entity/ActivationType.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/entity/ActivationType.java
@@ -1,0 +1,30 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.entity;
+
+/**
+ * Activation type specifying how activation will be handled.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public enum ActivationType {
+    CODE,
+    CUSTOM
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/ActivationLayer1Request.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/ActivationLayer1Request.java
@@ -1,0 +1,85 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.request.v3;
+
+import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
+
+import java.util.Map;
+
+/**
+ * Request object for activation layer 1.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+public class ActivationLayer1Request {
+
+    private ActivationType type;
+    private Map<String, String> identityAttributes;
+    private EciesEncryptedRequest activationData;
+
+    /**
+     * Get activation type.
+     * @return Activation type.
+     */
+    public ActivationType getType() {
+        return type;
+    }
+
+    /**
+     * Set activation type.
+     * @param type Activation type.
+     */
+    public void setType(ActivationType type) {
+        this.type = type;
+    }
+
+    /**
+     * Get identity attributes.
+     * @return Identity attributes.
+     */
+    public Map<String, String> getIdentityAttributes() {
+        return identityAttributes;
+    }
+
+    /**
+     * Set identity attributes.
+     * @param identityAttributes Identity attributes.
+     */
+    public void setIdentityAttributes(Map<String, String> identityAttributes) {
+        this.identityAttributes = identityAttributes;
+    }
+
+    /**
+     * Get encrypted activation data.
+     * @return Encrypted activation data.
+     */
+    public EciesEncryptedRequest getActivationData() {
+        return activationData;
+    }
+
+    /**
+     * Set encrypted activation data.
+     * @param activationData Encrypted activation data.
+     */
+    public void setActivationData(EciesEncryptedRequest activationData) {
+        this.activationData = activationData;
+    }
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/ActivationLayer2Request.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/ActivationLayer2Request.java
@@ -1,0 +1,81 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.request.v3;
+
+/**
+ * Request object for activation layer 2.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+public class ActivationLayer2Request {
+
+    private String devicePublicKey;
+    private String activationName;
+    private String extras;
+
+    /**
+     * Get Base64 encoded device public key.
+     * @return Device public key.
+     */
+    public String getDevicePublicKey() {
+        return devicePublicKey;
+    }
+
+    /**
+     * Set Base64 encoded device public key.
+     * @param devicePublicKey Device public key.
+     */
+    public void setDevicePublicKey(String devicePublicKey) {
+        this.devicePublicKey = devicePublicKey;
+    }
+
+    /**
+     * Get activation name.
+     * @return Activation name.
+     */
+    public String getActivationName() {
+        return activationName;
+    }
+
+    /**
+     * Set activation name.
+     * @param activationName Activation name.
+     */
+    public void setActivationName(String activationName) {
+        this.activationName = activationName;
+    }
+
+    /**
+     * Get activation extras.
+     * @return Activation extras.
+     */
+    public String getExtras() {
+        return extras;
+    }
+
+    /**
+     * Set activation extras.
+     * @param extras Activation extras.
+     */
+    public void setExtras(String extras) {
+        this.extras = extras;
+    }
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/EciesEncryptedRequest.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/EciesEncryptedRequest.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright (C) 2018 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,21 +17,37 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-package io.getlime.security.powerauth.rest.api.model.response.v3;
+package io.getlime.security.powerauth.rest.api.model.request.v3;
 
 /**
- * Response object for the /pa/v3/token endpoint, that enables fetching token for simple authentication.
+ * Request object with data encrypted by ECIES encryption.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class TokenCreateResponse {
+public class EciesEncryptedRequest {
 
+    private String ephemeralPublicKey;
     private String encryptedData;
     private String mac;
 
     /**
-     * Get encrypted data payload.
+     * Get Base64 encoded ephemeral public key.
+     * @return Ephemeral public key.
+     */
+    public String getEphemeralPublicKey() {
+        return ephemeralPublicKey;
+    }
+
+    /**
+     * Set Base64 encoded ephemeral public key.
+     * @param ephemeralPublicKey Ephemeral public key.
+     */
+    public void setEphemeralPublicKey(String ephemeralPublicKey) {
+        this.ephemeralPublicKey = ephemeralPublicKey;
+    }
+
+    /**
+     * Get Base64 encoded encrypted data.
      * @return Encrypted data.
      */
     public String getEncryptedData() {
@@ -39,7 +55,7 @@ public class TokenCreateResponse {
     }
 
     /**
-     * Set encrypted data payload.
+     * Set Base64 encoded encrypted data.
      * @param encryptedData Encrypted data.
      */
     public void setEncryptedData(String encryptedData) {
@@ -47,19 +63,18 @@ public class TokenCreateResponse {
     }
 
     /**
-     * Get MAC signature of the request.
-     * @return MAC of the request.
+     * Get Base64 encoded MAC of key and data.
+     * @return MAC of key and data.
      */
     public String getMac() {
         return mac;
     }
 
     /**
-     * Set MAC signature of the request.
-     * @param mac MAC of the request.
+     * Set Base64 encoded MAC of key and data.
+     * @param mac MAC of key and data.
      */
     public void setMac(String mac) {
         this.mac = mac;
     }
-
 }

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationLayer1Response.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationLayer1Response.java
@@ -1,0 +1,66 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.response.v3;
+
+import java.util.Map;
+
+/**
+ * Response object for activation layer 2.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+public class ActivationLayer1Response {
+
+    private EciesEncryptedResponse activationData;
+    private Map<String, Object> customAttributes;
+
+    /**
+     * Get encrypted activation data.
+     * @return Encrypted activation data.
+     */
+    public EciesEncryptedResponse getActivationData() {
+        return activationData;
+    }
+
+    /**
+     * Set encrypted activation data.
+     * @param activationData Encrypted activation data.
+     */
+    public void setActivationData(EciesEncryptedResponse activationData) {
+        this.activationData = activationData;
+    }
+
+    /**
+     * Get custom attributes for activation.
+     * @return Custom attributes.
+     */
+    public Map<String, Object> getCustomAttributes() {
+        return customAttributes;
+    }
+
+    /**
+     * Set custom attributes for activation.
+     * @param customAttributes Custom attributes.
+     */
+    public void setCustomAttributes(Map<String, Object> customAttributes) {
+        this.customAttributes = customAttributes;
+    }
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationLayer2Response.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationLayer2Response.java
@@ -1,0 +1,81 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.response.v3;
+
+/**
+ * Response object for activation layer 2.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+public class ActivationLayer2Response {
+
+    private String activationId;
+    private String serverPublicKey;
+    private String ctrData;
+
+    /**
+     * Get activation ID.
+     * @return Activation ID.
+     */
+    public String getActivationId() {
+        return activationId;
+    }
+
+    /**
+     * Set activation ID.
+     * @param activationId Activation ID.
+     */
+    public void setActivationId(String activationId) {
+        this.activationId = activationId;
+    }
+
+    /**
+     * Get Base64 encoded server public key.
+     * @return Server public key.
+     */
+    public String getServerPublicKey() {
+        return serverPublicKey;
+    }
+
+    /**
+     * Set Base64 encoded server public key.
+     * @param serverPublicKey Server public key.
+     */
+    public void setServerPublicKey(String serverPublicKey) {
+        this.serverPublicKey = serverPublicKey;
+    }
+
+    /**
+     * Get Base64 encoded counter data.
+     * @return Counter data.
+     */
+    public String getCtrData() {
+        return ctrData;
+    }
+
+    /**
+     * Set Base64 encoded counter data.
+     * @param ctrData Counter data.
+     */
+    public void setCtrData(String ctrData) {
+        this.ctrData = ctrData;
+    }
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/EciesEncryptedResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/EciesEncryptedResponse.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright (C) 2018 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,38 +17,36 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-package io.getlime.security.powerauth.rest.api.model.request.v3;
+package io.getlime.security.powerauth.rest.api.model.response.v3;
 
 /**
- * Request object for the /pa/v3/token endpoint, that enables fetching token for simple authentication.
+ * Response object for endpoints returning data encrypted by ECIES.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class TokenCreateRequest {
+public class EciesEncryptedResponse {
 
-    private String ephemeralKey;
     private String encryptedData;
     private String mac;
 
     /**
-     * Get Base64 encoded ephemeral public key.
-     * @return Ephemeral public key.
+     * Default constructor.
      */
-    public String getEphemeralKey() {
-        return ephemeralKey;
+    public EciesEncryptedResponse() {
     }
 
     /**
-     * Set Base64 encoded ephemeral public key.
-     * @param ephemeralKey Ephemeral public key.
+     * Constructor with Base64 encoded encrypted data and MAC of key and data.
+     * @param encryptedData Encrypted data.
+     * @param mac MAC of key and data.
      */
-    public void setEphemeralKey(String ephemeralKey) {
-        this.ephemeralKey = ephemeralKey;
+    public EciesEncryptedResponse(String encryptedData, String mac) {
+        this.encryptedData = encryptedData;
+        this.mac = mac;
     }
 
     /**
-     * Get Base64 encoded encrypted data.
+     * Get Base64 encoded encrypted data payload.
      * @return Encrypted data.
      */
     public String getEncryptedData() {
@@ -56,7 +54,7 @@ public class TokenCreateRequest {
     }
 
     /**
-     * Set Base64 encoded encrypted data.
+     * Set Base64 encoded encrypted data payload.
      * @param encryptedData Encrypted data.
      */
     public void setEncryptedData(String encryptedData) {
@@ -64,18 +62,19 @@ public class TokenCreateRequest {
     }
 
     /**
-     * Get Base64 encoded MAC of key and data.
-     * @return MAC of key and data.
+     * Get Base64 encoded MAC signature of the response.
+     * @return MAC of the response.
      */
     public String getMac() {
         return mac;
     }
 
     /**
-     * Set Base64 encoded MAC of key and data.
-     * @param mac MAC of key and data.
+     * Set Base64 encoded MAC signature of the response.
+     * @param mac MAC of the response.
      */
     public void setMac(String mac) {
         this.mac = mac;
     }
+
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/TokenController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/TokenController.java
@@ -30,9 +30,9 @@ import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAu
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.jaxrs.converter.v3.SignatureTypeConverter;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
-import io.getlime.security.powerauth.rest.api.model.request.v3.TokenCreateRequest;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveRequest;
-import io.getlime.security.powerauth.rest.api.model.response.v3.TokenCreateResponse;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.model.response.v3.TokenRemoveResponse;
 import io.getlime.security.powerauth.soap.axis.client.PowerAuthServiceClient;
 import org.slf4j.LoggerFactory;
@@ -71,9 +71,9 @@ public class TokenController {
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
     @Path("create")
-    public ObjectResponse<TokenCreateResponse> createToken(ObjectRequest<TokenCreateRequest> request,
-                                                           @HeaderParam(PowerAuthTokenHttpHeader.HEADER_NAME) String tokenHeader,
-                                                           @HeaderParam(PowerAuthSignatureHttpHeader.HEADER_NAME) String authHeader) throws PowerAuthAuthenticationException {
+    public EciesEncryptedResponse createToken(EciesEncryptedRequest request,
+                                              @HeaderParam(PowerAuthTokenHttpHeader.HEADER_NAME) String tokenHeader,
+                                              @HeaderParam(PowerAuthSignatureHttpHeader.HEADER_NAME) String authHeader) throws PowerAuthAuthenticationException {
 
         try {
 
@@ -98,10 +98,9 @@ public class TokenController {
                 final PowerAuthSignatureTypes signatureFactors = authentication.getSignatureFactors();
 
                 // Fetch data from the request
-                final TokenCreateRequest requestObject = request.getRequestObject();
-                final String ephemeralPublicKey = requestObject.getEphemeralKey();
-                final String encryptedData = requestObject.getEncryptedData();
-                final String mac = requestObject.getMac();
+                final String ephemeralPublicKey = request.getEphemeralPublicKey();
+                final String encryptedData = request.getEncryptedData();
+                final String mac = request.getMac();
 
                 // Prepare a signature type converter
                 SignatureTypeConverter converter = new SignatureTypeConverter();
@@ -116,10 +115,10 @@ public class TokenController {
                         encryptedData, mac, converter.convertFrom(signatureFactors));
 
                 // Prepare a response
-                final io.getlime.security.powerauth.rest.api.model.response.v3.TokenCreateResponse responseObject = new io.getlime.security.powerauth.rest.api.model.response.v3.TokenCreateResponse();
+                final EciesEncryptedResponse responseObject = new EciesEncryptedResponse();
                 responseObject.setMac(token.getMac());
                 responseObject.setEncryptedData(token.getEncryptedData());
-                return new ObjectResponse<>(responseObject);
+                return responseObject;
             } else {
                 throw new PowerAuthAuthenticationException();
             }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthEncryptionArgumentResolver.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthEncryptionArgumentResolver.java
@@ -44,19 +44,28 @@ public class PowerAuthEncryptionArgumentResolver implements HandlerMethodArgumen
 
     @Override
     public boolean supportsParameter(@NonNull MethodParameter parameter) {
-        return parameter.hasMethodAnnotation(PowerAuthEncryption.class) && parameter.hasParameterAnnotation(EncryptedRequestBody.class);
+        return parameter.hasMethodAnnotation(PowerAuthEncryption.class)
+                && (parameter.hasParameterAnnotation(EncryptedRequestBody.class) || PowerAuthEciesEncryption.class.isAssignableFrom(parameter.getParameterType()));
     }
 
     @Override
     public Object resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer, @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         final PowerAuthEciesEncryption eciesObject = (PowerAuthEciesEncryption) request.getAttribute(PowerAuthEncryption.ENCRYPTION_OBJECT);
-        final Class<?> parameterType = parameter.getParameterType();
-        try {
-            return objectMapper.readValue(eciesObject.getDecryptedRequest(), parameterType);
-        } catch (IOException e) {
-            return null;
+        // Decrypted object is inserted into parameter annotated by @EncryptedRequestBody annotation
+        if (parameter.hasParameterAnnotation(EncryptedRequestBody.class) && eciesObject != null && eciesObject.getDecryptedRequest() != null) {
+            final Class<?> parameterType = parameter.getParameterType();
+            try {
+                return objectMapper.readValue(eciesObject.getDecryptedRequest(), parameterType);
+            } catch (IOException e) {
+                return null;
+            }
         }
+        // Ecies encryption object is inserted into parameter which is of type PowerAuthEciesEncryption
+        if (PowerAuthEciesEncryption.class.isAssignableFrom(parameter.getParameterType())) {
+            return eciesObject;
+        }
+        return null;
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright (C) 2018 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,25 +17,30 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.spring.controller.v2;
+package io.getlime.security.powerauth.rest.api.spring.controller.v3;
 
 import com.google.common.io.BaseEncoding;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.powerauth.soap.v3.GetActivationStatusResponse;
-import io.getlime.powerauth.soap.v2.PrepareActivationResponse;
+import io.getlime.powerauth.soap.v3.PrepareActivationResponse;
 import io.getlime.powerauth.soap.v3.RemoveActivationResponse;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.application.PowerAuthApplicationConfiguration;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
+import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncryption;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
-import io.getlime.security.powerauth.rest.api.model.request.v2.ActivationCreateRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v2.ActivationStatusRequest;
-import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationCreateResponse;
+import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationRemoveResponse;
 import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationStatusResponse;
+import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationLayer1Response;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import io.getlime.security.powerauth.rest.api.spring.annotation.EncryptedRequestBody;
+import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuthEncryption;
 import io.getlime.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
 import org.slf4j.LoggerFactory;
@@ -50,15 +55,14 @@ import javax.servlet.http.HttpServletRequest;
  *
  * <h5>PowerAuth protocol versions:</h5>
  * <ul>
- *     <li>2.0</li>
- *     <li>2.1</li>
+ *     <li>3.0</li>
  * </ul>
  *
- * @author Petr Dvorak, petr@lime-company.eu
+ * @author Roman Strobl, roman.strobl@wultra.com
  *
  */
-@RestController("ActivationControllerV2")
-@RequestMapping(value = "/pa/activation")
+@RestController("ActivationControllerV3")
+@RequestMapping(value = "/pa/v3/activation")
 public class ActivationController {
 
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(ActivationController.class);
@@ -84,48 +88,50 @@ public class ActivationController {
         this.applicationConfiguration = applicationConfiguration;
     }
 
-    /**
-     * Create a new activation.
-     * @param request PowerAuth RESTful request with {@link ActivationCreateRequest} payload.
-     * @return PowerAuth RESTful response with {@link ActivationCreateResponse} payload.
-     * @throws PowerAuthActivationException In case creating activation fails.
-     */
     @RequestMapping(value = "create", method = RequestMethod.POST)
-    public ObjectResponse<ActivationCreateResponse> createActivation(
-            @RequestBody ObjectRequest<ActivationCreateRequest> request
-    ) throws PowerAuthActivationException {
+    @PowerAuthEncryption
+    public ActivationLayer1Response createActivation(@EncryptedRequestBody ActivationLayer1Request request,
+                                                     PowerAuthEciesEncryption eciesEncryption) throws PowerAuthAuthenticationException {
+
+        if (eciesEncryption == null) {
+            throw new PowerAuthAuthenticationException("ECIES object is missing");
+        }
         try {
-            String activationIDShort = request.getRequestObject().getActivationIdShort();
-            String activationNonce = request.getRequestObject().getActivationNonce();
-            String cDevicePublicKey = request.getRequestObject().getEncryptedDevicePublicKey();
-            String activationName = request.getRequestObject().getActivationName();
-            String extras = request.getRequestObject().getExtras();
-            String applicationKey = request.getRequestObject().getApplicationKey();
-            String applicationSignature = request.getRequestObject().getApplicationSignature();
-            String clientEphemeralKey = request.getRequestObject().getEphemeralPublicKey();
 
-            PrepareActivationResponse soapResponse = powerAuthClient.v2().prepareActivation(
-                    activationIDShort,
-                    activationName,
-                    activationNonce,
-                    clientEphemeralKey,
-                    cDevicePublicKey,
-                    extras,
-                    applicationKey,
-                    applicationSignature
-            );
+            switch (request.getType()) {
+                // Regular activation which uses "code" identity attribute
+                case CODE:
+                    // Extract data from request and encryption object
+                    String activationCode = request.getIdentityAttributes().get("code");
+                    String applicationKey = eciesEncryption.getApplicationKey();
+                    EciesEncryptedRequest activationData = request.getActivationData();
+                    String ephemeralPublicKey = activationData.getEphemeralPublicKey();
+                    String encryptedData = activationData.getEncryptedData();
+                    String mac = activationData.getMac();
 
-            ActivationCreateResponse response = new ActivationCreateResponse();
-            response.setActivationId(soapResponse.getActivationId());
-            response.setActivationNonce(soapResponse.getActivationNonce());
-            response.setEncryptedServerPublicKey(soapResponse.getEncryptedServerPublicKey());
-            response.setEncryptedServerPublicKeySignature(soapResponse.getEncryptedServerPublicKeySignature());
-            response.setEphemeralPublicKey(soapResponse.getEphemeralPublicKey());
+                    // Call PrepareActivation SOAP method on PA server
+                    PrepareActivationResponse response = powerAuthClient.prepareActivation(activationCode, applicationKey, ephemeralPublicKey, encryptedData, mac);
 
-            return new ObjectResponse<>(response);
+                    // Prepare encrypted response object for layer 2
+                    EciesEncryptedResponse encryptedResponseL2 = new EciesEncryptedResponse();
+                    encryptedResponseL2.setEncryptedData(response.getEncryptedData());
+                    encryptedResponseL2.setMac(response.getMac());
+
+                    // The response is encrypted once more before sent to client using ResponseBodyAdvice
+                    ActivationLayer1Response responseL1 = new ActivationLayer1Response();
+                    responseL1.setActivationData(encryptedResponseL2);
+                    return responseL1;
+
+                // Custom activation
+                case CUSTOM:
+                    throw new IllegalStateException("Not implemented yet");
+
+                default:
+                    throw new PowerAuthAuthenticationException("Unsupported activation type: "+request.getType());
+            }
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth activation failed.", ex);
-            throw new PowerAuthActivationException();
+            throw new PowerAuthAuthenticationException(ex.getMessage());
         }
     }
 
@@ -136,9 +142,8 @@ public class ActivationController {
      * @throws PowerAuthActivationException In case request fails.
      */
     @RequestMapping(value = "status", method = RequestMethod.POST)
-    public ObjectResponse<ActivationStatusResponse> getActivationStatus(
-            @RequestBody ObjectRequest<ActivationStatusRequest> request
-    ) throws PowerAuthActivationException {
+    public ObjectResponse<ActivationStatusResponse> getActivationStatus(@RequestBody ObjectRequest<ActivationStatusRequest> request)
+            throws PowerAuthActivationException {
         try {
             String activationId = request.getRequestObject().getActivationId();
             GetActivationStatusResponse soapResponse = powerAuthClient.getActivationStatus(activationId);
@@ -165,8 +170,8 @@ public class ActivationController {
     @RequestMapping(value = "remove", method = RequestMethod.POST)
     public ObjectResponse<ActivationRemoveResponse> removeActivation(
             @RequestHeader(value = PowerAuthSignatureHttpHeader.HEADER_NAME) String signatureHeader,
-            HttpServletRequest httpServletRequest
-    ) throws PowerAuthActivationException, PowerAuthAuthenticationException {
+            HttpServletRequest httpServletRequest)
+            throws PowerAuthActivationException, PowerAuthAuthenticationException {
         try {
             String requestBodyString = ((String) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
             byte[] requestBodyBytes = requestBodyString == null ? null : BaseEncoding.base64().decode(requestBodyString);
@@ -186,5 +191,4 @@ public class ActivationController {
             throw new PowerAuthActivationException();
         }
     }
-
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
@@ -27,9 +27,9 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
-import io.getlime.security.powerauth.rest.api.model.request.v3.TokenCreateRequest;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveRequest;
-import io.getlime.security.powerauth.rest.api.model.response.v3.TokenCreateResponse;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.model.response.v3.TokenRemoveResponse;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
 import io.getlime.security.powerauth.rest.api.spring.converter.v3.SignatureTypeConverter;
@@ -63,9 +63,9 @@ public class TokenController {
             PowerAuthSignatureTypes.POSSESSION_BIOMETRY,
             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
     })
-    public ObjectResponse<TokenCreateResponse> createToken(
-            @RequestBody ObjectRequest<TokenCreateRequest> request,
-            PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
+    public EciesEncryptedResponse createToken(@RequestBody EciesEncryptedRequest request,
+                                              PowerAuthApiAuthentication authentication)
+            throws PowerAuthAuthenticationException {
         try {
             if (authentication != null && authentication.getActivationId() != null) {
                 if (!"3.0".equals(authentication.getVersion())) {
@@ -77,10 +77,9 @@ public class TokenController {
                 final PowerAuthSignatureTypes signatureFactors = authentication.getSignatureFactors();
 
                 // Fetch data from the request
-                final TokenCreateRequest requestObject = request.getRequestObject();
-                final String ephemeralPublicKey = requestObject.getEphemeralKey();
-                final String encryptedData = requestObject.getEncryptedData();
-                final String mac = requestObject.getMac();
+                final String ephemeralPublicKey = request.getEphemeralPublicKey();
+                final String encryptedData = request.getEncryptedData();
+                final String mac = request.getMac();
 
                 // Prepare a signature type converter
                 SignatureTypeConverter converter = new SignatureTypeConverter();
@@ -95,10 +94,10 @@ public class TokenController {
                         encryptedData, mac, converter.convertFrom(signatureFactors));
 
                 // Prepare a response
-                final TokenCreateResponse responseObject = new TokenCreateResponse();
-                responseObject.setMac(token.getMac());
-                responseObject.setEncryptedData(token.getEncryptedData());
-                return new ObjectResponse<>(responseObject);
+                final EciesEncryptedResponse response = new EciesEncryptedResponse();
+                response.setMac(token.getMac());
+                response.setEncryptedData(token.getEncryptedData());
+                return response;
             } else {
                 throw new PowerAuthAuthenticationException();
             }
@@ -117,7 +116,8 @@ public class TokenController {
             PowerAuthSignatureTypes.POSSESSION_BIOMETRY,
             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
     })
-    public ObjectResponse<TokenRemoveResponse> removeToken(@RequestBody ObjectRequest<TokenRemoveRequest> request, PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
+    public ObjectResponse<TokenRemoveResponse> removeToken(@RequestBody ObjectRequest<TokenRemoveRequest> request,
+                                                           PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         try {
             if (authentication != null && authentication.getActivationId() != null) {
 


### PR DESCRIPTION
This PR introduces activations and fixes several issues which were necessary to be fixed to get activations working:
- Fix #72: Crypto 3.0: New activation
- Partial fix of #85 Crypto 3.0: Extracting request body for ECIES reads input stream (complete fix is out of scope of this pull request)
- Argument resolver for PowerAuthEciesEncryption class which injects ECIES object as method parameter
- Introduce common requests and response model classes for ECIES
- Migrate existing ECIES based controllers to ECIES model classes
- Add signature verification to activation remove endpoints