### PR TITLE
Fix #93: Crypto 3.0: Unify error handling in REST endpoints, updates based on test results

### DIFF
--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/ActivationStatusRequest.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/ActivationStatusRequest.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright (C) 2018 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -20,9 +20,9 @@
 package io.getlime.security.powerauth.rest.api.model.request.v3;
 
 /**
- * Request object for /pa/v3/activation/status end-point
+ * Request object for /pa/v3/activation/status end-point.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  *
  */
 public class ActivationStatusRequest {

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/ActivationStatusRequest.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/v3/ActivationStatusRequest.java
@@ -1,0 +1,48 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.request.v3;
+
+/**
+ * Request object for /pa/v3/activation/status end-point
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ *
+ */
+public class ActivationStatusRequest {
+
+    private String activationId;
+
+    /**
+     * Get activation ID
+     * @return Activation ID
+     */
+    public String getActivationId() {
+        return activationId;
+    }
+
+    /**
+     * Set activation ID
+     * @param activationId Activation ID
+     */
+    public void setActivationId(String activationId) {
+        this.activationId = activationId;
+    }
+
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationRemoveResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationRemoveResponse.java
@@ -1,0 +1,48 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.response.v3;
+
+/**
+ * Response object for /pa/v3/activation/remove end-point
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ *
+ */
+public class ActivationRemoveResponse {
+
+    private String activationId;
+
+    /**
+     * Get activation ID
+     * @return Activation ID
+     */
+    public String getActivationId() {
+        return activationId;
+    }
+
+    /**
+     * Set activation ID
+     * @param activationId Activation ID
+     */
+    public void setActivationId(String activationId) {
+        this.activationId = activationId;
+    }
+
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationRemoveResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationRemoveResponse.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright (C) 2018 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -20,9 +20,9 @@
 package io.getlime.security.powerauth.rest.api.model.response.v3;
 
 /**
- * Response object for /pa/v3/activation/remove end-point
+ * Response object for /pa/v3/activation/remove end-point.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  *
  */
 public class ActivationRemoveResponse {

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationStatusResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationStatusResponse.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright (C) 2018 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -22,9 +22,9 @@ package io.getlime.security.powerauth.rest.api.model.response.v3;
 import java.util.Map;
 
 /**
- * Response object for /pa/v3/activation/status end-point
+ * Response object for /pa/v3/activation/status end-point.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  *
  */
 public class ActivationStatusResponse {

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationStatusResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ActivationStatusResponse.java
@@ -1,0 +1,84 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.response.v3;
+
+import java.util.Map;
+
+/**
+ * Response object for /pa/v3/activation/status end-point
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ *
+ */
+public class ActivationStatusResponse {
+
+    private String activationId;
+    private String encryptedStatusBlob;
+    private Map<String, Object> customObject;
+
+    /**
+     * Get activation ID
+     * @return Activation ID
+     */
+    public String getActivationId() {
+        return activationId;
+    }
+
+    /**
+     * Set activation ID
+     * @param activationId Activation ID
+     */
+    public void setActivationId(String activationId) {
+        this.activationId = activationId;
+    }
+
+    /**
+     * Get encrypted activation status blob
+     * @return Encrypted activation status blob
+     */
+    public String getEncryptedStatusBlob() {
+        return encryptedStatusBlob;
+    }
+
+    /**
+     * Set encrypted activation status blob
+     * @param cStatusBlob encrypted activation status blob
+     */
+    public void setEncryptedStatusBlob(String cStatusBlob) {
+        this.encryptedStatusBlob = cStatusBlob;
+    }
+
+    /**
+     * Get custom associated object.
+     * @return Custom associated object
+     */
+    public Map<String, Object> getCustomObject() {
+        return customObject;
+    }
+
+    /**
+     * Set custom associated object
+     * @param customObject Custom associated object
+     */
+    public void setCustomObject(Map<String, Object> customObject) {
+        this.customObject = customObject;
+    }
+
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ServiceStatusResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ServiceStatusResponse.java
@@ -1,19 +1,22 @@
 /*
- * Copyright 2016 Lime - HighTech Solutions s.r.o.
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright (C) 2018 Wultra s.r.o.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package io.getlime.security.powerauth.rest.api.model.response.v3;
 
 import java.util.Date;

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ServiceStatusResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/v3/ServiceStatusResponse.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.getlime.security.powerauth.rest.api.model.response.v2;
+package io.getlime.security.powerauth.rest.api.model.response.v3;
 
 import java.util.Date;
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
@@ -32,12 +32,12 @@ import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncr
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
-import io.getlime.security.powerauth.rest.api.model.request.v2.ActivationStatusRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
+import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
-import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationRemoveResponse;
-import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationStatusResponse;
 import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationLayer1Response;
+import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationRemoveResponse;
+import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationStatusResponse;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.annotation.EncryptedRequestBody;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuthEncryption;
@@ -91,10 +91,10 @@ public class ActivationController {
     @RequestMapping(value = "create", method = RequestMethod.POST)
     @PowerAuthEncryption
     public ActivationLayer1Response createActivation(@EncryptedRequestBody ActivationLayer1Request request,
-                                                     PowerAuthEciesEncryption eciesEncryption) throws PowerAuthAuthenticationException {
+                                                     PowerAuthEciesEncryption eciesEncryption) throws PowerAuthActivationException {
 
         if (eciesEncryption == null) {
-            throw new PowerAuthAuthenticationException("ECIES object is missing");
+            throw new PowerAuthActivationException();
         }
         try {
 
@@ -131,7 +131,7 @@ public class ActivationController {
             }
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth activation failed.", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            throw new PowerAuthActivationException();
         }
     }
 

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/ServiceController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/ServiceController.java
@@ -18,7 +18,7 @@ package io.getlime.security.powerauth.app.rest.api.spring.controller;
 
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.app.rest.api.spring.configuration.PowerAuthWebServiceConfiguration;
-import io.getlime.security.powerauth.rest.api.model.response.v2.ServiceStatusResponse;
+import io.getlime.security.powerauth.rest.api.model.response.v3.ServiceStatusResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Controller;


### PR DESCRIPTION
This PR fixes minor issues found while executing automated tests:
- Fix #93: Crypto 3.0: Unify error handling in REST endpoints
- Introduce request/response objects for `/pa/v3/activation/status` and `/pa/v3/activation/remove`
- Move service status endpoint to `v3`