### PR TITLE
Fix #102: Crypto 3.0: Handle new exceptions from powerauth-crypto

### DIFF
--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/encryption/PowerAuthNonPersonalizedEncryptor.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/encryption/PowerAuthNonPersonalizedEncryptor.java
@@ -26,9 +26,12 @@ import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.crypto.lib.encryptor.NonPersonalizedEncryptor;
 import io.getlime.security.powerauth.crypto.lib.encryptor.model.NonPersonalizedEncryptedMessage;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import io.getlime.security.powerauth.rest.api.model.entity.NonPersonalizedEncryptedPayloadModel;
 
 import java.io.IOException;
+import java.security.InvalidKeyException;
 
 /**
  * @author Petr Dvorak, petr@wultra.com
@@ -47,7 +50,7 @@ public class PowerAuthNonPersonalizedEncryptor {
         this.encryptor = new NonPersonalizedEncryptor(applicationKey, sessionKeyBytes, sessionIndex, ephemeralKeyBytes);
     }
 
-    public ObjectResponse<NonPersonalizedEncryptedPayloadModel> encrypt(Object object) throws JsonProcessingException {
+    public ObjectResponse<NonPersonalizedEncryptedPayloadModel> encrypt(Object object) throws JsonProcessingException, GenericCryptoException, CryptoProviderException, InvalidKeyException {
         if (object == null) {
             return null;
         }
@@ -55,7 +58,7 @@ public class PowerAuthNonPersonalizedEncryptor {
         return this.encrypt(originalData);
     }
 
-    public ObjectResponse<NonPersonalizedEncryptedPayloadModel> encrypt(byte[] originalData) {
+    public ObjectResponse<NonPersonalizedEncryptedPayloadModel> encrypt(byte[] originalData) throws GenericCryptoException, CryptoProviderException, InvalidKeyException {
 
         if (originalData == null) {
             return null;
@@ -80,7 +83,7 @@ public class PowerAuthNonPersonalizedEncryptor {
         return new ObjectResponse<>(responseObject);
     }
 
-    public byte[] decrypt(ObjectRequest<NonPersonalizedEncryptedPayloadModel> request) {
+    public byte[] decrypt(ObjectRequest<NonPersonalizedEncryptedPayloadModel> request) throws GenericCryptoException, CryptoProviderException, InvalidKeyException {
 
         if (request == null) {
             return null;
@@ -105,7 +108,7 @@ public class PowerAuthNonPersonalizedEncryptor {
         return encryptor.decrypt(message);
     }
 
-    public <T> T decrypt(ObjectRequest<NonPersonalizedEncryptedPayloadModel> request, Class<T> resultClass) throws IOException {
+    public <T> T decrypt(ObjectRequest<NonPersonalizedEncryptedPayloadModel> request, Class<T> resultClass) throws IOException, GenericCryptoException, CryptoProviderException, InvalidKeyException {
         byte[] result = this.decrypt(request);
         if (result == null) {
             return null;

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/CustomActivationController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/CustomActivationController.java
@@ -23,6 +23,8 @@ import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.powerauth.soap.v2.PowerAuthPortV2ServiceStub;
 import io.getlime.security.powerauth.app.rest.api.javaee.provider.PowerAuthUserProvider;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthNonPersonalizedEncryptor;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.jaxrs.encryption.EncryptorFactory;
@@ -39,6 +41,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.util.Map;
 
 /**
@@ -114,7 +117,7 @@ public class CustomActivationController {
 
             return powerAuthApiResponse;
 
-        } catch (IOException e) {
+        } catch (IOException | GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
             throw new PowerAuthActivationException();
         }
 

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/CustomActivationController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/CustomActivationController.java
@@ -23,6 +23,8 @@ import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.powerauth.soap.v2.CreateActivationResponse;
 import io.getlime.security.powerauth.app.rest.api.spring.provider.PowerAuthUserProvider;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthNonPersonalizedEncryptor;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.model.entity.NonPersonalizedEncryptedPayloadModel;
@@ -39,6 +41,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.util.Map;
 
 /**
@@ -141,7 +144,7 @@ public class CustomActivationController {
             // Return response
             return powerAuthApiResponse;
 
-        } catch (IOException e) {
+        } catch (IOException | GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
             throw new PowerAuthActivationException();
         }
 

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/EncryptedDataExchangeController.java
@@ -21,6 +21,8 @@ package io.getlime.security.powerauth.app.rest.api.spring.controller;
 
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthNonPersonalizedEncryptor;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthEncryptionException;
 import io.getlime.security.powerauth.rest.api.model.entity.NonPersonalizedEncryptedPayloadModel;
@@ -31,6 +33,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.security.InvalidKeyException;
 
 /**
  * Sample end-point demonstrating how to receive and send encrypted data.
@@ -62,10 +66,10 @@ public class EncryptedDataExchangeController {
         }
 
         // Decrypt the request object
-        byte[] requestDataBytes = encryptor.decrypt(request);
-
-        // Decryption failed
-        if (requestDataBytes == null) {
+        byte[] requestDataBytes;
+        try {
+            requestDataBytes = encryptor.decrypt(request);
+        } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
             throw new PowerAuthEncryptionException();
         }
 
@@ -75,10 +79,10 @@ public class EncryptedDataExchangeController {
         String responseData = "Server successfully decrypted data: " + requestData;
 
         // Encrypt response data
-        ObjectResponse<NonPersonalizedEncryptedPayloadModel> encryptedResponse = encryptor.encrypt(responseData.getBytes());
-
-        // Encryption failed
-        if (encryptedResponse == null) {
+        ObjectResponse<NonPersonalizedEncryptedPayloadModel> encryptedResponse;
+        try {
+            encryptedResponse = encryptor.encrypt(responseData.getBytes());
+        } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
             throw new PowerAuthEncryptionException();
         }
 


### PR DESCRIPTION
This pull request migrates error handling to new exceptions from powerauth-crypto, which are thrown instead of returning null values.