### PR TITLE
Fix #85: Crypto 3.0: Extracting request body for ECIES reads input stream

### DIFF
--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/filter/PowerAuthRequestFilterBase.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/filter/PowerAuthRequestFilterBase.java
@@ -19,12 +19,13 @@
  */
 package io.getlime.security.powerauth.rest.api.base.filter;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.http.PowerAuthRequestCanonizationUtils;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Class representing for holding any static constants available to request filters.
@@ -36,7 +37,7 @@ public class PowerAuthRequestFilterBase {
     /**
      * Constant for the request attribute name "X-PowerAuth-Request-Body".
      */
-    public static final String POWERAUTH_SIGNATURE_BASE_STRING = "X-PowerAuth-Request-Body";
+    public static final String POWERAUTH_REQUEST_BODY = "X-PowerAuth-Request-Body";
 
     public static ResettableStreamHttpServletRequest filterRequest(HttpServletRequest httpRequest) throws IOException {
         ResettableStreamHttpServletRequest resettableRequest = new ResettableStreamHttpServletRequest(httpRequest);
@@ -55,8 +56,14 @@ public class PowerAuthRequestFilterBase {
                 // Pass the signature base string as the request attribute
                 if (signatureBaseStringData != null) {
                     resettableRequest.setAttribute(
-                            PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING,
-                            BaseEncoding.base64().encode(signatureBaseStringData.getBytes("UTF-8"))
+                            PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY,
+                            new PowerAuthRequestBody(signatureBaseStringData.getBytes(StandardCharsets.UTF_8))
+                    );
+                } else {
+                    // Store empty request body in request attribute
+                    resettableRequest.setAttribute(
+                            PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY,
+                            new PowerAuthRequestBody()
                     );
                 }
 
@@ -68,8 +75,14 @@ public class PowerAuthRequestFilterBase {
             byte[] body = resettableRequest.getRequestBody();
             if (body != null) {
                 resettableRequest.setAttribute(
-                        PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING,
-                        BaseEncoding.base64().encode(body)
+                        PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY,
+                        new PowerAuthRequestBody(body)
+                );
+            } else {
+                // Store empty request body in request attribute
+                resettableRequest.setAttribute(
+                        PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY,
+                        new PowerAuthRequestBody()
                 );
             }
         }

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/model/PowerAuthRequestBody.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/model/PowerAuthRequestBody.java
@@ -1,0 +1,53 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.base.model;
+
+/**
+ * Class representing HTTP request body.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthRequestBody {
+
+    private final byte[] requestBytes;
+
+    /**
+     * Default constructor for empty HTTP request body.
+     */
+    public PowerAuthRequestBody() {
+        this.requestBytes = new byte[0];
+    }
+
+    /**
+     * Constructor with HTTP request body bytes.
+     * @param requestBytes HTTP request body bytes.
+     */
+    public PowerAuthRequestBody(byte[] requestBytes) {
+        this.requestBytes = requestBytes;
+    }
+
+    /**
+     * Get HTTP request body bytes.
+     * @return HTTP request body bytes.
+     */
+    public byte[] getRequestBytes() {
+        return requestBytes;
+    }
+}

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthAuthenticationProviderBase.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthAuthenticationProviderBase.java
@@ -19,11 +19,11 @@
  */
 package io.getlime.security.powerauth.rest.api.base.provider;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -90,8 +90,8 @@ public abstract class PowerAuthAuthenticationProviderBase {
     public PowerAuthApiAuthentication validateRequestSignature(HttpServletRequest servletRequest, String requestUriIdentifier, String httpAuthorizationHeader, List<PowerAuthSignatureTypes> allowedSignatureTypes) throws PowerAuthAuthenticationException {
         // Get HTTP method and body bytes
         String requestMethod = servletRequest.getMethod().toUpperCase();
-        String requestBodyString = ((String) servletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
-        byte[] requestBodyBytes = requestBodyString == null ? null : BaseEncoding.base64().decode(requestBodyString);
+        PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) servletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+        byte[] requestBodyBytes = requestBody.getRequestBytes();
         return this.validateRequestSignature(requestMethod, requestBodyBytes, requestUriIdentifier, httpAuthorizationHeader, allowedSignatureTypes, null);
     }
 
@@ -108,8 +108,8 @@ public abstract class PowerAuthAuthenticationProviderBase {
     public PowerAuthApiAuthentication validateRequestSignature(HttpServletRequest servletRequest, String requestUriIdentifier, String httpAuthorizationHeader, List<PowerAuthSignatureTypes> allowedSignatureTypes, @Nullable Integer forcedSignatureVersion) throws PowerAuthAuthenticationException {
         // Get HTTP method and body bytes
         String requestMethod = servletRequest.getMethod().toUpperCase();
-        String requestBodyString = ((String) servletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
-        byte[] requestBodyBytes = requestBodyString == null ? null : BaseEncoding.base64().decode(requestBodyString);
+        PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) servletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+        byte[] requestBodyBytes = requestBody.getRequestBytes();
         return this.validateRequestSignature(requestMethod, requestBodyBytes, requestUriIdentifier, httpAuthorizationHeader, allowedSignatureTypes, forcedSignatureVersion);
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
@@ -30,6 +30,7 @@ import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeader
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.jaxrs.converter.v2.SignatureTypeConverter;
 import io.getlime.security.powerauth.rest.api.model.request.v2.VaultUnlockRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.VaultUnlockResponse;
@@ -96,8 +97,8 @@ public class SecureVaultController {
                 }
             }
 
-            String requestBodyString = ((String) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
-            byte[] requestBodyBytes = requestBodyString == null ? null : BaseEncoding.base64().decode(requestBodyString);
+            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+            byte[] requestBodyBytes = requestBody.getRequestBytes();
 
             String data = PowerAuthHttpBody.getSignatureBaseString("POST", "/pa/vault/unlock", BaseEncoding.base64().decode(nonce), requestBodyBytes);
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthAnnotationInterceptor.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthAnnotationInterceptor.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncr
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthEncryptionException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.spring.provider.PowerAuthEncryptionProvider;
@@ -157,11 +158,11 @@ public class PowerAuthAnnotationInterceptor extends HandlerInterceptorAdapter {
 
         try {
             // Parse ECIES cryptogram from request body
-            String requestBodyString = ((String) request.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
-            if (requestBodyString == null || requestBodyString.isEmpty()) {
+            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) request.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+            byte[] requestBodyBytes = requestBody.getRequestBytes();
+            if (requestBodyBytes.length == 0) {
                 throw new PowerAuthEncryptionException("Invalid HTTP request");
             }
-            byte[] requestBodyBytes = BaseEncoding.base64().decode(requestBodyString);
             final EciesEncryptedRequest eciesRequest = objectMapper.readValue(requestBodyBytes, EciesEncryptedRequest.class);
 
             // Prepare ephemeral public key

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthAnnotationInterceptor.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthAnnotationInterceptor.java
@@ -160,7 +160,7 @@ public class PowerAuthAnnotationInterceptor extends HandlerInterceptorAdapter {
             // Parse ECIES cryptogram from request body
             PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) request.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
             byte[] requestBodyBytes = requestBody.getRequestBytes();
-            if (requestBodyBytes.length == 0) {
+            if (requestBodyBytes == null || requestBodyBytes.length == 0) {
                 throw new PowerAuthEncryptionException("Invalid HTTP request");
             }
             final EciesEncryptedRequest eciesRequest = objectMapper.readValue(requestBodyBytes, EciesEncryptedRequest.class);

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SecureVaultController.java
@@ -30,6 +30,7 @@ import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeader
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.model.request.v2.VaultUnlockRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.VaultUnlockResponse;
 import io.getlime.security.powerauth.rest.api.spring.converter.v2.SignatureTypeConverter;
@@ -118,8 +119,9 @@ public class SecureVaultController {
                 }
 
                 // Use POST request body as data for signature.
-                String requestBodyString = ((String) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
-                requestBodyBytes = requestBodyString == null ? null : BaseEncoding.base64().decode(requestBodyString);
+
+                PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+                requestBodyBytes = requestBody.getRequestBytes();
             } else {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
                 throw new PowerAuthSecureVaultException();

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
@@ -19,7 +19,6 @@
  */
 package io.getlime.security.powerauth.rest.api.spring.controller.v3;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.powerauth.soap.v3.GetActivationStatusResponse;
@@ -32,6 +31,7 @@ import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncr
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -178,8 +178,8 @@ public class ActivationController {
             HttpServletRequest httpServletRequest)
             throws PowerAuthActivationException, PowerAuthAuthenticationException {
         try {
-            String requestBodyString = ((String) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
-            byte[] requestBodyBytes = requestBodyString == null ? null : BaseEncoding.base64().decode(requestBodyString);
+            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+            byte[] requestBodyBytes = requestBody.getRequestBytes();
             PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/activation/remove", signatureHeader);
             if (apiAuthentication != null && apiAuthentication.getActivationId() != null) {
                 RemoveActivationResponse soapResponse = powerAuthClient.removeActivation(apiAuthentication.getActivationId());

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
@@ -29,6 +29,7 @@ import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeader
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.converter.v3.SignatureTypeConverter;
@@ -109,8 +110,8 @@ public class SecureVaultController {
             final String mac = request.getMac();
 
             // Prepare data for signature to allow signature verification on PowerAuth server
-            String requestBodyString = ((String) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
-            byte[] requestBodyBytes = requestBodyString == null ? null : BaseEncoding.base64().decode(requestBodyString);
+            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+            byte[] requestBodyBytes = requestBody.getRequestBytes();
             String data = PowerAuthHttpBody.getSignatureBaseString("POST", "/pa/vault/unlock", BaseEncoding.base64().decode(nonce), requestBodyBytes);
 
             // Verify signature and get encrypted vault encryption key from PowerAuth server

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
@@ -159,7 +159,7 @@ public class UpgradeController {
             // Extract request body
             PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
             byte[] requestBodyBytes = requestBody.getRequestBytes();
-            if (requestBodyBytes.length == 0) {
+            if (requestBodyBytes == null || requestBodyBytes.length == 0) {
                 // Expected request body is {}, do not accept empty body
                 throw new PowerAuthAuthenticationException();
             }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
@@ -19,7 +19,6 @@
  */
 package io.getlime.security.powerauth.rest.api.spring.controller.v3;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.powerauth.soap.v3.CommitUpgradeResponse;
 import io.getlime.powerauth.soap.v3.StartUpgradeResponse;
@@ -33,6 +32,7 @@ import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAu
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthUpgradeException;
 import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
@@ -157,13 +157,12 @@ public class UpgradeController {
             }
 
             // Extract request body
-            String requestBodyString = ((String) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_SIGNATURE_BASE_STRING));
-            if (requestBodyString == null) {
+            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+            byte[] requestBodyBytes = requestBody.getRequestBytes();
+            if (requestBodyBytes.length == 0) {
                 // Expected request body is {}, do not accept empty body
                 throw new PowerAuthAuthenticationException();
             }
-
-            byte[] requestBodyBytes = BaseEncoding.base64().decode(requestBodyString);
 
             // Verify signature, force signature version during upgrade to version 3
             List<PowerAuthSignatureTypes> allowedSignatureTypes = Collections.singletonList(PowerAuthSignatureTypes.POSSESSION);


### PR DESCRIPTION
This PR fixes the remaining part of the issue which is related to storing and retrieving request body without base-64 encoding and null pointer handling.