### PR TITLE
Fix #88: Crypto 3.0: Move common controller code to services

### DIFF
--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SignatureController.java
@@ -24,6 +24,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,6 +46,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/pa/signature")
 public class SignatureController {
 
+    private static final Logger logger = LoggerFactory.getLogger(SignatureController.class);
+
     /**
      * Validate signature by validating any data sent in request to this end-point.
      * @param auth Automatically injected PowerAuth authentication object.
@@ -59,6 +63,10 @@ public class SignatureController {
     public Response validateSignature(PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
 
         if (auth != null && auth.getActivationId() != null) {
+            if (!"2.0".equals(auth.getVersion()) && !"2.1".equals(auth.getVersion())) {
+                logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
+                throw new PowerAuthAuthenticationException();
+            }
             return new Response();
         } else {
             throw new PowerAuthAuthenticationException("Signature validation failed");

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
@@ -21,11 +21,7 @@ package io.getlime.security.powerauth.rest.api.spring.controller.v3;
 
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
-import io.getlime.powerauth.soap.v3.GetActivationStatusResponse;
-import io.getlime.powerauth.soap.v3.PrepareActivationResponse;
-import io.getlime.powerauth.soap.v3.RemoveActivationResponse;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
-import io.getlime.security.powerauth.rest.api.base.application.PowerAuthApplicationConfiguration;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncryption;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
@@ -34,15 +30,13 @@ import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilter
 import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
-import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationLayer1Response;
 import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationRemoveResponse;
 import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationStatusResponse;
-import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.annotation.EncryptedRequestBody;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuthEncryption;
 import io.getlime.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
-import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import io.getlime.security.powerauth.rest.api.spring.service.v3.ActivationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,15 +62,13 @@ public class ActivationController {
 
     private static final Logger logger = LoggerFactory.getLogger(ActivationController.class);
 
-    private PowerAuthServiceClient powerAuthClient;
-
     private PowerAuthAuthenticationProvider authenticationProvider;
 
-    private PowerAuthApplicationConfiguration applicationConfiguration;
+    private ActivationService activationServiceV3;
 
     @Autowired
-    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
-        this.powerAuthClient = powerAuthClient;
+    public void setActivationServiceV3(ActivationService activationServiceV3) {
+        this.activationServiceV3 = activationServiceV3;
     }
 
     @Autowired
@@ -84,56 +76,14 @@ public class ActivationController {
         this.authenticationProvider = authenticationProvider;
     }
 
-    @Autowired(required = false)
-    public void setApplicationConfiguration(PowerAuthApplicationConfiguration applicationConfiguration) {
-        this.applicationConfiguration = applicationConfiguration;
-    }
-
     @RequestMapping(value = "create", method = RequestMethod.POST)
     @PowerAuthEncryption
     public ActivationLayer1Response createActivation(@EncryptedRequestBody ActivationLayer1Request request,
                                                      PowerAuthEciesEncryption eciesEncryption) throws PowerAuthActivationException {
-
-        if (eciesEncryption == null) {
+        if (request == null || eciesEncryption == null) {
             throw new PowerAuthActivationException();
         }
-        try {
-
-            switch (request.getType()) {
-                // Regular activation which uses "code" identity attribute
-                case CODE:
-                    // Extract data from request and encryption object
-                    String activationCode = request.getIdentityAttributes().get("code");
-                    String applicationKey = eciesEncryption.getApplicationKey();
-                    EciesEncryptedRequest activationData = request.getActivationData();
-                    String ephemeralPublicKey = activationData.getEphemeralPublicKey();
-                    String encryptedData = activationData.getEncryptedData();
-                    String mac = activationData.getMac();
-
-                    // Call PrepareActivation SOAP method on PA server
-                    PrepareActivationResponse response = powerAuthClient.prepareActivation(activationCode, applicationKey, ephemeralPublicKey, encryptedData, mac);
-
-                    // Prepare encrypted response object for layer 2
-                    EciesEncryptedResponse encryptedResponseL2 = new EciesEncryptedResponse();
-                    encryptedResponseL2.setEncryptedData(response.getEncryptedData());
-                    encryptedResponseL2.setMac(response.getMac());
-
-                    // The response is encrypted once more before sent to client using ResponseBodyAdvice
-                    ActivationLayer1Response responseL1 = new ActivationLayer1Response();
-                    responseL1.setActivationData(encryptedResponseL2);
-                    return responseL1;
-
-                // Custom activation
-                case CUSTOM:
-                    throw new IllegalStateException("Not implemented yet");
-
-                default:
-                    throw new PowerAuthAuthenticationException("Unsupported activation type: "+request.getType());
-            }
-        } catch (Exception ex) {
-            logger.warn("Creating PowerAuth activation failed.", ex);
-            throw new PowerAuthActivationException();
-        }
+        return activationServiceV3.createActivation(request, eciesEncryption);
     }
 
     /**
@@ -146,23 +96,10 @@ public class ActivationController {
     public ObjectResponse<ActivationStatusResponse> getActivationStatus(@RequestBody ObjectRequest<ActivationStatusRequest> request)
             throws PowerAuthActivationException {
         if (request.getRequestObject() == null || request.getRequestObject().getActivationId() == null) {
-            logger.warn("Invalid request object in activation status.");
+            logger.warn("Invalid request object in activation status");
             throw new PowerAuthActivationException();
         }
-        try {
-            String activationId = request.getRequestObject().getActivationId();
-            GetActivationStatusResponse soapResponse = powerAuthClient.getActivationStatus(activationId);
-            ActivationStatusResponse response = new ActivationStatusResponse();
-            response.setActivationId(soapResponse.getActivationId());
-            response.setEncryptedStatusBlob(soapResponse.getEncryptedStatusBlob());
-            if (applicationConfiguration != null) {
-                response.setCustomObject(applicationConfiguration.statusServiceCustomObject());
-            }
-            return new ObjectResponse<>(response);
-        } catch (Exception ex) {
-            logger.warn("PowerAuth activation status check failed.", ex);
-            throw new PowerAuthActivationException();
-        }
+        return new ObjectResponse<>(activationServiceV3.getActivationStatus(request.getRequestObject()));
     }
 
     /**
@@ -177,23 +114,16 @@ public class ActivationController {
             @RequestHeader(value = PowerAuthSignatureHttpHeader.HEADER_NAME) String signatureHeader,
             HttpServletRequest httpServletRequest)
             throws PowerAuthActivationException, PowerAuthAuthenticationException {
-        try {
-            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
-            byte[] requestBodyBytes = requestBody.getRequestBytes();
-            PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/activation/remove", signatureHeader);
-            if (apiAuthentication != null && apiAuthentication.getActivationId() != null) {
-                RemoveActivationResponse soapResponse = powerAuthClient.removeActivation(apiAuthentication.getActivationId());
-                ActivationRemoveResponse response = new ActivationRemoveResponse();
-                response.setActivationId(soapResponse.getActivationId());
-                return new ObjectResponse<>(response);
-            } else {
-                throw new PowerAuthAuthenticationException("USER_NOT_AUTHENTICATED");
-            }
-        } catch (PowerAuthAuthenticationException ex) {
-            throw ex;
-        } catch (Exception ex) {
-            logger.warn("PowerAuth activation removal failed.", ex);
-            throw new PowerAuthActivationException();
+        PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+        byte[] requestBodyBytes = requestBody.getRequestBytes();
+        PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/activation/remove", signatureHeader);
+        if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
+            throw new PowerAuthAuthenticationException("Signature validation failed");
         }
+        if (!"3.0".equals(apiAuthentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
+            throw new PowerAuthAuthenticationException();
+        }
+        return new ObjectResponse<>(activationServiceV3.removeActivation(apiAuthentication));
     }
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
@@ -24,6 +24,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,6 +45,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/pa/v3/signature")
 public class SignatureController {
 
+    private static final Logger logger = LoggerFactory.getLogger(SignatureController.class);
+
     /**
      * Validate signature by validating any data sent in request to this end-point.
      * @param auth Automatically injected PowerAuth authentication object.
@@ -58,6 +62,10 @@ public class SignatureController {
     public Response validateSignature(PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
 
         if (auth != null && auth.getActivationId() != null) {
+            if (!"3.0".equals(auth.getVersion())) {
+                logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
+                throw new PowerAuthAuthenticationException();
+            }
             return new Response();
         } else {
             throw new PowerAuthAuthenticationException("Signature validation failed");

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
@@ -21,9 +21,7 @@ package io.getlime.security.powerauth.rest.api.spring.controller.v3;
 
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
-import io.getlime.powerauth.soap.v3.CreateTokenResponse;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
-import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -31,8 +29,7 @@ import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveReques
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.model.response.v3.TokenRemoveResponse;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
-import io.getlime.security.powerauth.rest.api.spring.converter.v3.SignatureTypeConverter;
-import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import io.getlime.security.powerauth.rest.api.spring.service.v3.TokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,13 +54,20 @@ public class TokenController {
 
     private static final Logger logger = LoggerFactory.getLogger(TokenController.class);
 
-    private PowerAuthServiceClient powerAuthClient;
+    private TokenService tokenServiceV3;
 
     @Autowired
-    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
-        this.powerAuthClient = powerAuthClient;
+    public void setTokenServiceV3(TokenService tokenServiceV3) {
+        this.tokenServiceV3 = tokenServiceV3;
     }
 
+    /**
+     * Create token.
+     * @param request ECIES encrypted create token request.
+     * @param authentication PowerAuth API authentication object.
+     * @return ECIES encrypted create token response.
+     * @throws PowerAuthAuthenticationException In case authentication fails or request is invalid.
+     */
     @RequestMapping(value = "create", method = RequestMethod.POST)
     @PowerAuth(resourceId = "/pa/token/create", signatureType = {
             PowerAuthSignatureTypes.POSSESSION,
@@ -74,49 +78,28 @@ public class TokenController {
     public EciesEncryptedResponse createToken(@RequestBody EciesEncryptedRequest request,
                                               PowerAuthApiAuthentication authentication)
             throws PowerAuthAuthenticationException {
-        try {
-            if (authentication != null && authentication.getActivationId() != null) {
-                if (!"3.0".equals(authentication.getVersion())) {
-                    logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                    throw new PowerAuthAuthenticationException();
-                }
-
-                // Fetch activation ID and signature type
-                final PowerAuthSignatureTypes signatureFactors = authentication.getSignatureFactors();
-
-                // Fetch data from the request
-                final String ephemeralPublicKey = request.getEphemeralPublicKey();
-                final String encryptedData = request.getEncryptedData();
-                final String mac = request.getMac();
-
-                // Prepare a signature type converter
-                SignatureTypeConverter converter = new SignatureTypeConverter();
-
-                // Get ECIES headers
-                String activationId = authentication.getActivationId();
-                PowerAuthSignatureHttpHeader httpHeader = (PowerAuthSignatureHttpHeader) authentication.getHttpHeader();
-                String applicationKey = httpHeader.getApplicationKey();
-
-                // Create a token
-                final CreateTokenResponse token = powerAuthClient.createToken(activationId, applicationKey, ephemeralPublicKey,
-                        encryptedData, mac, converter.convertFrom(signatureFactors));
-
-                // Prepare a response
-                final EciesEncryptedResponse response = new EciesEncryptedResponse();
-                response.setMac(token.getMac());
-                response.setEncryptedData(token.getEncryptedData());
-                return response;
-            } else {
+        if (request == null) {
+            logger.warn("Invalid request object in create token");
+            throw new PowerAuthAuthenticationException();
+        }
+        if (authentication != null && authentication.getActivationId() != null) {
+            if (!"3.0".equals(authentication.getVersion())) {
+                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                 throw new PowerAuthAuthenticationException();
             }
-        }  catch (PowerAuthAuthenticationException ex) {
-            throw ex;
-        } catch (Exception ex) {
-            logger.warn("Creating PowerAuth token failed.", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            return tokenServiceV3.createToken(request, authentication);
+        } else {
+            throw new PowerAuthAuthenticationException();
         }
     }
 
+    /**
+     * Remove token.
+     * @param request ECIES encrypted remove token request.
+     * @param authentication PowerAuth API authentication object.
+     * @return ECIES encrypted remove token response.
+     * @throws PowerAuthAuthenticationException In case authentication fails or request is invalid.
+     */
     @RequestMapping(value = "remove", method = RequestMethod.POST)
     @PowerAuth(resourceId = "/pa/token/remove", signatureType = {
             PowerAuthSignatureTypes.POSSESSION,
@@ -126,32 +109,18 @@ public class TokenController {
     })
     public ObjectResponse<TokenRemoveResponse> removeToken(@RequestBody ObjectRequest<TokenRemoveRequest> request,
                                                            PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
-        try {
-            if (authentication != null && authentication.getActivationId() != null) {
-
-                // Fetch activation ID
-                final String activationId = authentication.getActivationId();
-
-                // Fetch token ID from the request
-                final TokenRemoveRequest requestObject = request.getRequestObject();
-                final String tokenId = requestObject.getTokenId();
-
-                // Remove a token, ignore response, since the endpoint should quietly return
-                powerAuthClient.removeToken(tokenId, activationId);
-
-                // Prepare a response
-                final TokenRemoveResponse responseObject = new TokenRemoveResponse();
-                responseObject.setTokenId(tokenId);
-                return new ObjectResponse<>(responseObject);
-
-            } else {
+        if (request.getRequestObject() == null) {
+            logger.warn("Invalid request object in remove token");
+            throw new PowerAuthAuthenticationException();
+        }
+        if (authentication != null && authentication.getActivationId() != null) {
+            if (!"3.0".equals(authentication.getVersion())) {
+                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                 throw new PowerAuthAuthenticationException();
             }
-        }  catch (PowerAuthAuthenticationException ex) {
-            throw ex;
-        } catch (Exception ex) {
-            logger.warn("Removing PowerAuth token failed.", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
+        } else {
+            throw new PowerAuthAuthenticationException();
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
@@ -20,31 +20,22 @@
 package io.getlime.security.powerauth.rest.api.spring.controller.v3;
 
 import io.getlime.core.rest.model.base.response.Response;
-import io.getlime.powerauth.soap.v3.CommitUpgradeResponse;
-import io.getlime.powerauth.soap.v3.StartUpgradeResponse;
-import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthEncryptionHttpHeader;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.http.validator.InvalidPowerAuthHttpHeaderException;
 import io.getlime.security.powerauth.http.validator.PowerAuthEncryptionHttpHeaderValidator;
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
-import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthUpgradeException;
-import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
-import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
-import io.getlime.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
-import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import io.getlime.security.powerauth.rest.api.spring.service.v3.UpgradeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Controller responsible for upgrade.
@@ -62,17 +53,11 @@ public class UpgradeController {
 
     private static final Logger logger = LoggerFactory.getLogger(UpgradeController.class);
 
-    private PowerAuthServiceClient powerAuthClient;
-    private PowerAuthAuthenticationProvider authenticationProvider;
+    private UpgradeService upgradeService;
 
     @Autowired
-    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
-        this.powerAuthClient = powerAuthClient;
-    }
-
-    @Autowired
-    public void setAuthenticationProvider(PowerAuthAuthenticationProvider authenticationProvider) {
-        this.authenticationProvider = authenticationProvider;
+    public void setUpgradeService(UpgradeService upgradeService) {
+        this.upgradeService = upgradeService;
     }
 
     /**
@@ -88,43 +73,28 @@ public class UpgradeController {
                                                  @RequestHeader(value = PowerAuthEncryptionHttpHeader.HEADER_NAME, defaultValue = "unknown") String encryptionHeader)
             throws PowerAuthUpgradeException {
 
-        try {
-            // Parse the encryption header
-            PowerAuthEncryptionHttpHeader header = new PowerAuthEncryptionHttpHeader().fromValue(encryptionHeader);
-
-            // Validate the encryption header
-            try {
-                PowerAuthEncryptionHttpHeaderValidator.validate(header);
-            } catch (InvalidPowerAuthHttpHeaderException e) {
-                throw new PowerAuthUpgradeException(e.getMessage());
-            }
-
-            if (!"3.0".equals(header.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-                throw new PowerAuthAuthenticationException();
-            }
-
-            // Fetch data from the request
-            final String ephemeralPublicKey = request.getEphemeralPublicKey();
-            final String encryptedData = request.getEncryptedData();
-            final String mac = request.getMac();
-
-            // Get ECIES headers
-            final String activationId = header.getActivationId();
-            final String applicationKey = header.getApplicationKey();
-
-            // Start upgrade on PowerAuth server
-            StartUpgradeResponse upgradeResponse = powerAuthClient.startUpgrade(activationId, applicationKey, ephemeralPublicKey, encryptedData, mac);
-
-            // Prepare a response
-            final EciesEncryptedResponse response = new EciesEncryptedResponse();
-            response.setMac(upgradeResponse.getMac());
-            response.setEncryptedData(upgradeResponse.getEncryptedData());
-            return response;
-        } catch (Exception ex) {
-            logger.warn("PowerAuth upgrade start failed.", ex);
+        if (request == null) {
+            logger.warn("Invalid request object in upgrade start");
             throw new PowerAuthUpgradeException();
         }
+
+        // Parse the encryption header
+        PowerAuthEncryptionHttpHeader header = new PowerAuthEncryptionHttpHeader().fromValue(encryptionHeader);
+
+        // Validate the encryption header
+        try {
+            PowerAuthEncryptionHttpHeaderValidator.validate(header);
+        } catch (InvalidPowerAuthHttpHeaderException ex) {
+            throw new PowerAuthUpgradeException(ex.getMessage());
+        }
+
+        if (!"3.0".equals(header.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
+            throw new PowerAuthUpgradeException();
+        }
+
+        return upgradeService.upgradeStart(request, header);
+
     }
 
     /**
@@ -140,57 +110,21 @@ public class UpgradeController {
                                   HttpServletRequest httpServletRequest)
             throws PowerAuthAuthenticationException, PowerAuthUpgradeException {
 
+        // Parse the signature header
+        PowerAuthSignatureHttpHeader header = new PowerAuthSignatureHttpHeader().fromValue(signatureHeader);
+
+        // Validate the signature header
         try {
-            // Parse the signature header
-            PowerAuthSignatureHttpHeader header = new PowerAuthSignatureHttpHeader().fromValue(signatureHeader);
-
-            // Validate the signature header
-            try {
-                PowerAuthSignatureHttpHeaderValidator.validate(header);
-            } catch (InvalidPowerAuthHttpHeaderException e) {
-                throw new PowerAuthUpgradeException(e.getMessage());
-            }
-
-            if (!"3.0".equals(header.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-                throw new PowerAuthAuthenticationException();
-            }
-
-            // Extract request body
-            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
-            byte[] requestBodyBytes = requestBody.getRequestBytes();
-            if (requestBodyBytes == null || requestBodyBytes.length == 0) {
-                // Expected request body is {}, do not accept empty body
-                throw new PowerAuthAuthenticationException();
-            }
-
-            // Verify signature, force signature version during upgrade to version 3
-            List<PowerAuthSignatureTypes> allowedSignatureTypes = Collections.singletonList(PowerAuthSignatureTypes.POSSESSION);
-            PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/upgrade/commit", signatureHeader, allowedSignatureTypes, 3);
-
-            // In case signature verification fails, upgrade fails, too
-            if (authentication == null || authentication.getActivationId() == null) {
-                throw new PowerAuthAuthenticationException();
-            }
-
-            // Get signature HTTP headers
-            final String activationId = authentication.getActivationId();
-            final PowerAuthSignatureHttpHeader httpHeader = (PowerAuthSignatureHttpHeader) authentication.getHttpHeader();
-            final String applicationKey = httpHeader.getApplicationKey();
-
-            // Commit upgrade on PowerAuth server
-            CommitUpgradeResponse upgradeResponse = powerAuthClient.commitUpgrade(activationId, applicationKey);
-
-            if (upgradeResponse.isCommitted()) {
-                return new Response();
-            } else {
-                throw new PowerAuthUpgradeException();
-            }
-        } catch (PowerAuthAuthenticationException ex) {
-            throw ex;
-        } catch (Exception ex) {
-            logger.warn("PowerAuth upgrade commit failed.", ex);
-            throw new PowerAuthUpgradeException();
+            PowerAuthSignatureHttpHeaderValidator.validate(header);
+        } catch (InvalidPowerAuthHttpHeaderException ex) {
+            throw new PowerAuthUpgradeException(ex.getMessage());
         }
+
+        if (!"3.0".equals(header.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
+            throw new PowerAuthAuthenticationException();
+        }
+
+        return upgradeService.upgradeCommit(signatureHeader, httpServletRequest);
     }
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/ActivationService.java
@@ -1,0 +1,98 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.spring.service.v2;
+
+import io.getlime.powerauth.soap.v2.PrepareActivationResponse;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
+import io.getlime.security.powerauth.rest.api.model.request.v2.ActivationCreateRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationCreateResponse;
+import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service implementing activation functionality.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Service("ActivationServiceV2")
+public class ActivationService {
+
+    private PowerAuthServiceClient powerAuthClient;
+
+    private static final Logger logger = LoggerFactory.getLogger(ActivationService.class);
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    /**
+     * Create activation.
+     * @param request Create activation request.
+     * @return Create activation response.
+     * @throws PowerAuthActivationException In case create activation fails.
+     */
+    public ActivationCreateResponse createActivation(ActivationCreateRequest request) throws PowerAuthActivationException {
+        try {
+            String activationIDShort = request.getActivationIdShort();
+            String activationNonce = request.getActivationNonce();
+            String cDevicePublicKey = request.getEncryptedDevicePublicKey();
+            String activationName = request.getActivationName();
+            String extras = request.getExtras();
+            String applicationKey = request.getApplicationKey();
+            String applicationSignature = request.getApplicationSignature();
+            String clientEphemeralKey = request.getEphemeralPublicKey();
+
+            PrepareActivationResponse soapResponse = powerAuthClient.v2().prepareActivation(
+                    activationIDShort,
+                    activationName,
+                    activationNonce,
+                    clientEphemeralKey,
+                    cDevicePublicKey,
+                    extras,
+                    applicationKey,
+                    applicationSignature
+            );
+
+            ActivationCreateResponse response = new ActivationCreateResponse();
+            response.setActivationId(soapResponse.getActivationId());
+            response.setActivationNonce(soapResponse.getActivationNonce());
+            response.setEncryptedServerPublicKey(soapResponse.getEncryptedServerPublicKey());
+            response.setEncryptedServerPublicKeySignature(soapResponse.getEncryptedServerPublicKeySignature());
+            response.setEphemeralPublicKey(soapResponse.getEphemeralPublicKey());
+
+            return response;
+        } catch (Exception ex) {
+            logger.warn("Creating PowerAuth activation failed", ex);
+            throw new PowerAuthActivationException();
+        }
+    }
+
+}

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/SecureVaultService.java
@@ -1,0 +1,142 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.spring.service.v2;
+
+import com.google.common.io.BaseEncoding;
+import io.getlime.powerauth.soap.v2.SignatureType;
+import io.getlime.security.powerauth.http.PowerAuthHttpBody;
+import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
+import io.getlime.security.powerauth.http.validator.InvalidPowerAuthHttpHeaderException;
+import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
+import io.getlime.security.powerauth.rest.api.model.request.v2.VaultUnlockRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v2.VaultUnlockResponse;
+import io.getlime.security.powerauth.rest.api.spring.converter.v2.SignatureTypeConverter;
+import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Service implementing secure vault functionality.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Service("SecureVaultServiceV2")
+public class SecureVaultService {
+
+    private static final Logger logger = LoggerFactory.getLogger(SecureVaultService.class);
+
+    private PowerAuthServiceClient powerAuthClient;
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    /**
+     * Unlock secure vault.
+     * @param signatureHeader PowerAuth signature HTTP header.
+     * @param request Vault unlock request.
+     * @param httpServletRequest HTTP servlet request.
+     * @return Vault unlock response.
+     * @throws PowerAuthSecureVaultException In case vault unlock fails.
+     * @throws PowerAuthAuthenticationException In case authentication fails.
+     */
+    public VaultUnlockResponse vaultUnlock(String signatureHeader,
+                                           VaultUnlockRequest request,
+                                           HttpServletRequest httpServletRequest) throws PowerAuthSecureVaultException, PowerAuthAuthenticationException {
+        try {
+            // Parse the header
+            PowerAuthSignatureHttpHeader header = new PowerAuthSignatureHttpHeader().fromValue(signatureHeader);
+
+            // Validate the header
+            try {
+                PowerAuthSignatureHttpHeaderValidator.validate(header);
+            } catch (InvalidPowerAuthHttpHeaderException e) {
+                throw new PowerAuthAuthenticationException(e.getMessage());
+            }
+
+            SignatureTypeConverter converter = new SignatureTypeConverter();
+
+            String activationId = header.getActivationId();
+            String applicationId = header.getApplicationKey();
+            String signature = header.getSignature();
+            SignatureType signatureType = converter.convertFrom(header.getSignatureType());
+            String nonce = header.getNonce();
+
+            String reason = null;
+            byte[] requestBodyBytes;
+
+            if ("2.0".equals(header.getVersion())) {
+                // Version 2.0 requires null data in signature for vault unlock.
+                requestBodyBytes = null;
+            } else if ("2.1".equals(header.getVersion())) {
+                // Version 2.1 or higher requires request data in signature (POST request body) for vault unlock.
+                if (request != null) {
+                    // Send vault unlock reason, in case it is available.
+                    if (request.getReason() != null) {
+                        reason = request.getReason();
+                    }
+                }
+
+                // Use POST request body as data for signature.
+
+                PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+                requestBodyBytes = requestBody.getRequestBytes();
+            } else {
+                throw new PowerAuthSecureVaultException();
+            }
+
+            String data = PowerAuthHttpBody.getSignatureBaseString("POST", "/pa/vault/unlock", BaseEncoding.base64().decode(nonce), requestBodyBytes);
+
+            io.getlime.powerauth.soap.v2.VaultUnlockResponse soapResponse = powerAuthClient.v2().unlockVault(activationId, applicationId, data, signature, signatureType, reason);
+
+            if (!soapResponse.isSignatureValid()) {
+                throw new PowerAuthAuthenticationException();
+            }
+
+            VaultUnlockResponse response = new VaultUnlockResponse();
+            response.setActivationId(soapResponse.getActivationId());
+            response.setEncryptedVaultEncryptionKey(soapResponse.getEncryptedVaultEncryptionKey());
+
+            return response;
+        } catch (PowerAuthAuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            logger.warn("PowerAuth vault unlock failed", ex);
+            throw new PowerAuthSecureVaultException();
+        }
+    }
+
+}

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/TokenService.java
@@ -1,0 +1,92 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.spring.service.v2;
+
+import io.getlime.powerauth.soap.v2.CreateTokenResponse;
+import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v2.TokenCreateResponse;
+import io.getlime.security.powerauth.rest.api.spring.converter.v2.SignatureTypeConverter;
+import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service implementing token functionality.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Service("TokenServiceV2")
+public class TokenService {
+
+    private static final Logger logger = LoggerFactory.getLogger(TokenService.class);
+
+    private PowerAuthServiceClient powerAuthClient;
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    /**
+     * Create token.
+     * @param request Create token request.
+     * @param authentication PowerAuth API authentication.
+     * @return Create token response.
+     * @throws PowerAuthAuthenticationException In case token could not be created.
+     */
+    public TokenCreateResponse createToken(TokenCreateRequest request, PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
+        try {
+            // Fetch activation ID and signature type
+            final String activationId = authentication.getActivationId();
+            final PowerAuthSignatureTypes signatureFactors = authentication.getSignatureFactors();
+
+            // Fetch data from the request
+            final String ephemeralPublicKey = request.getEphemeralPublicKey();
+
+            // Prepare a signature type converter
+            SignatureTypeConverter converter = new SignatureTypeConverter();
+
+            // Create a token
+            final CreateTokenResponse token = powerAuthClient.v2().createToken(activationId, ephemeralPublicKey, converter.convertFrom(signatureFactors));
+
+            // Prepare a response
+            final TokenCreateResponse response = new TokenCreateResponse();
+            response.setMac(token.getMac());
+            response.setEncryptedData(token.getEncryptedData());
+            return response;
+        } catch (Exception ex) {
+            logger.warn("Creating PowerAuth token failed", ex);
+            throw new PowerAuthAuthenticationException(ex.getMessage());
+        }
+    }
+
+}

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
@@ -49,7 +49,6 @@ import org.springframework.stereotype.Service;
  * </ul>
  *
  * @author Roman Strobl, roman.strobl@wultra.com
- *
  */
 @Service("ActivationServiceV3")
 public class ActivationService {
@@ -72,6 +71,7 @@ public class ActivationService {
 
     /**
      * Create activation.
+     *
      * @param request Create activation layer 1 request.
      * @param eciesEncryption PowerAuth ECIES encryption object.
      * @return Create activation layer 1 response.
@@ -109,7 +109,7 @@ public class ActivationService {
                     throw new IllegalStateException("Not implemented yet");
 
                 default:
-                    throw new PowerAuthAuthenticationException("Unsupported activation type: "+request.getType());
+                    throw new PowerAuthAuthenticationException("Unsupported activation type: " + request.getType());
             }
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth activation failed", ex);
@@ -119,6 +119,7 @@ public class ActivationService {
 
     /**
      * Get activation status.
+     *
      * @param request Activation status request.
      * @return Activation status response.
      * @throws PowerAuthActivationException In case retrieving activation status fails.
@@ -142,23 +143,18 @@ public class ActivationService {
 
     /**
      * Remove activation.
+     *
      * @param apiAuthentication PowerAuth API authentication object.
      * @return Activation remove response.
-     * @throws PowerAuthActivationException In case remove activation fails.
+     * @throws PowerAuthActivationException     In case remove activation fails.
      * @throws PowerAuthAuthenticationException In case authentication fails.
      */
-    public ActivationRemoveResponse removeActivation(PowerAuthApiAuthentication apiAuthentication) throws PowerAuthActivationException, PowerAuthAuthenticationException {
+    public ActivationRemoveResponse removeActivation(PowerAuthApiAuthentication apiAuthentication) throws PowerAuthActivationException {
         try {
-            if (apiAuthentication != null && apiAuthentication.getActivationId() != null) {
-                RemoveActivationResponse soapResponse = powerAuthClient.removeActivation(apiAuthentication.getActivationId());
-                ActivationRemoveResponse response = new ActivationRemoveResponse();
-                response.setActivationId(soapResponse.getActivationId());
-                return response;
-            } else {
-                throw new PowerAuthAuthenticationException("USER_NOT_AUTHENTICATED");
-            }
-        } catch (PowerAuthAuthenticationException ex) {
-            throw ex;
+            RemoveActivationResponse soapResponse = powerAuthClient.removeActivation(apiAuthentication.getActivationId());
+            ActivationRemoveResponse response = new ActivationRemoveResponse();
+            response.setActivationId(soapResponse.getActivationId());
+            return response;
         } catch (Exception ex) {
             logger.warn("PowerAuth activation removal failed", ex);
             throw new PowerAuthActivationException();

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
@@ -147,7 +147,6 @@ public class ActivationService {
      * @param apiAuthentication PowerAuth API authentication object.
      * @return Activation remove response.
      * @throws PowerAuthActivationException     In case remove activation fails.
-     * @throws PowerAuthAuthenticationException In case authentication fails.
      */
     public ActivationRemoveResponse removeActivation(PowerAuthApiAuthentication apiAuthentication) throws PowerAuthActivationException {
         try {

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
@@ -1,0 +1,167 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.spring.service.v3;
+
+import io.getlime.powerauth.soap.v3.GetActivationStatusResponse;
+import io.getlime.powerauth.soap.v3.PrepareActivationResponse;
+import io.getlime.powerauth.soap.v3.RemoveActivationResponse;
+import io.getlime.security.powerauth.rest.api.base.application.PowerAuthApplicationConfiguration;
+import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
+import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncryption;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
+import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationLayer1Response;
+import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationRemoveResponse;
+import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationStatusResponse;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service implementing activation functionality.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>3.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Service("ActivationServiceV3")
+public class ActivationService {
+
+    private PowerAuthServiceClient powerAuthClient;
+
+    private PowerAuthApplicationConfiguration applicationConfiguration;
+
+    private static final Logger logger = LoggerFactory.getLogger(ActivationService.class);
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    @Autowired(required = false)
+    public void setApplicationConfiguration(PowerAuthApplicationConfiguration applicationConfiguration) {
+        this.applicationConfiguration = applicationConfiguration;
+    }
+
+    /**
+     * Create activation.
+     * @param request Create activation layer 1 request.
+     * @param eciesEncryption PowerAuth ECIES encryption object.
+     * @return Create activation layer 1 response.
+     * @throws PowerAuthActivationException In case create activation fails.
+     */
+    public ActivationLayer1Response createActivation(ActivationLayer1Request request, PowerAuthEciesEncryption eciesEncryption) throws PowerAuthActivationException {
+        try {
+
+            switch (request.getType()) {
+                // Regular activation which uses "code" identity attribute
+                case CODE:
+                    // Extract data from request and encryption object
+                    String activationCode = request.getIdentityAttributes().get("code");
+                    String applicationKey = eciesEncryption.getApplicationKey();
+                    EciesEncryptedRequest activationData = request.getActivationData();
+                    String ephemeralPublicKey = activationData.getEphemeralPublicKey();
+                    String encryptedData = activationData.getEncryptedData();
+                    String mac = activationData.getMac();
+
+                    // Call PrepareActivation SOAP method on PA server
+                    PrepareActivationResponse response = powerAuthClient.prepareActivation(activationCode, applicationKey, ephemeralPublicKey, encryptedData, mac);
+
+                    // Prepare encrypted response object for layer 2
+                    EciesEncryptedResponse encryptedResponseL2 = new EciesEncryptedResponse();
+                    encryptedResponseL2.setEncryptedData(response.getEncryptedData());
+                    encryptedResponseL2.setMac(response.getMac());
+
+                    // The response is encrypted once more before sent to client using ResponseBodyAdvice
+                    ActivationLayer1Response responseL1 = new ActivationLayer1Response();
+                    responseL1.setActivationData(encryptedResponseL2);
+                    return responseL1;
+
+                // Custom activation
+                case CUSTOM:
+                    throw new IllegalStateException("Not implemented yet");
+
+                default:
+                    throw new PowerAuthAuthenticationException("Unsupported activation type: "+request.getType());
+            }
+        } catch (Exception ex) {
+            logger.warn("Creating PowerAuth activation failed", ex);
+            throw new PowerAuthActivationException();
+        }
+    }
+
+    /**
+     * Get activation status.
+     * @param request Activation status request.
+     * @return Activation status response.
+     * @throws PowerAuthActivationException In case retrieving activation status fails.
+     */
+    public ActivationStatusResponse getActivationStatus(ActivationStatusRequest request) throws PowerAuthActivationException {
+        try {
+            String activationId = request.getActivationId();
+            GetActivationStatusResponse soapResponse = powerAuthClient.getActivationStatus(activationId);
+            ActivationStatusResponse response = new ActivationStatusResponse();
+            response.setActivationId(soapResponse.getActivationId());
+            response.setEncryptedStatusBlob(soapResponse.getEncryptedStatusBlob());
+            if (applicationConfiguration != null) {
+                response.setCustomObject(applicationConfiguration.statusServiceCustomObject());
+            }
+            return response;
+        } catch (Exception ex) {
+            logger.warn("PowerAuth activation status check failed", ex);
+            throw new PowerAuthActivationException();
+        }
+    }
+
+    /**
+     * Remove activation.
+     * @param apiAuthentication PowerAuth API authentication object.
+     * @return Activation remove response.
+     * @throws PowerAuthActivationException In case remove activation fails.
+     * @throws PowerAuthAuthenticationException In case authentication fails.
+     */
+    public ActivationRemoveResponse removeActivation(PowerAuthApiAuthentication apiAuthentication) throws PowerAuthActivationException, PowerAuthAuthenticationException {
+        try {
+            if (apiAuthentication != null && apiAuthentication.getActivationId() != null) {
+                RemoveActivationResponse soapResponse = powerAuthClient.removeActivation(apiAuthentication.getActivationId());
+                ActivationRemoveResponse response = new ActivationRemoveResponse();
+                response.setActivationId(soapResponse.getActivationId());
+                return response;
+            } else {
+                throw new PowerAuthAuthenticationException("USER_NOT_AUTHENTICATED");
+            }
+        } catch (PowerAuthAuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            logger.warn("PowerAuth activation removal failed", ex);
+            throw new PowerAuthActivationException();
+        }
+    }
+}

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/SecureVaultService.java
@@ -1,0 +1,112 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.spring.service.v3;
+
+import com.google.common.io.BaseEncoding;
+import io.getlime.powerauth.soap.v3.SignatureType;
+import io.getlime.powerauth.soap.v3.VaultUnlockResponse;
+import io.getlime.security.powerauth.http.PowerAuthHttpBody;
+import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import io.getlime.security.powerauth.rest.api.spring.converter.v3.SignatureTypeConverter;
+import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Service implementing secure vault functionality.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>3.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Service("SecureVaultServiceV3")
+public class SecureVaultService {
+
+    private PowerAuthServiceClient powerAuthClient;
+
+    private static final Logger logger = LoggerFactory.getLogger(SecureVaultService.class);
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    /**
+     * Unlock secure vault.
+     * @param header PowerAuth signature HTTP header.
+     * @param request ECIES encrypted vault unlock request.
+     * @param httpServletRequest HTTP servlet request.
+     * @return ECIES encrypted vault unlock response.
+     * @throws PowerAuthSecureVaultException In case vault unlock request fails.
+     * @throws PowerAuthAuthenticationException In case authentication fails.
+     */
+    public EciesEncryptedResponse vaultUnlock(PowerAuthSignatureHttpHeader header,
+                                              EciesEncryptedRequest request,
+                                              HttpServletRequest httpServletRequest) throws PowerAuthSecureVaultException, PowerAuthAuthenticationException {
+        try {
+            io.getlime.security.powerauth.rest.api.spring.converter.v3.SignatureTypeConverter converter = new SignatureTypeConverter();
+
+            String activationId = header.getActivationId();
+            String applicationKey = header.getApplicationKey();
+            String signature = header.getSignature();
+            SignatureType signatureType = converter.convertFrom(header.getSignatureType());
+            String nonce = header.getNonce();
+
+            // Fetch data from the request
+            final String ephemeralPublicKey = request.getEphemeralPublicKey();
+            final String encryptedData = request.getEncryptedData();
+            final String mac = request.getMac();
+
+            // Prepare data for signature to allow signature verification on PowerAuth server
+            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+            byte[] requestBodyBytes = requestBody.getRequestBytes();
+            String data = PowerAuthHttpBody.getSignatureBaseString("POST", "/pa/vault/unlock", BaseEncoding.base64().decode(nonce), requestBodyBytes);
+
+            // Verify signature and get encrypted vault encryption key from PowerAuth server
+            VaultUnlockResponse soapResponse = powerAuthClient.unlockVault(activationId, applicationKey, signature,
+                    signatureType, data, ephemeralPublicKey, encryptedData, mac);
+
+            if (!soapResponse.isSignatureValid()) {
+                throw new PowerAuthAuthenticationException();
+            }
+
+            return new EciesEncryptedResponse(soapResponse.getEncryptedData(), soapResponse.getMac());
+        } catch (PowerAuthAuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            logger.warn("PowerAuth vault unlock failed", ex);
+            throw new PowerAuthSecureVaultException();
+        }
+    }
+}

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
@@ -111,27 +111,19 @@ public class TokenService {
      */
     public TokenRemoveResponse removeToken(TokenRemoveRequest request, PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         try {
-            if (authentication != null && authentication.getActivationId() != null) {
+            // Fetch activation ID
+            final String activationId = authentication.getActivationId();
 
-                // Fetch activation ID
-                final String activationId = authentication.getActivationId();
+            // Fetch token ID from the request
+            final String tokenId = request.getTokenId();
 
-                // Fetch token ID from the request
-                final String tokenId = request.getTokenId();
+            // Remove a token, ignore response, since the endpoint should quietly return
+            powerAuthClient.removeToken(tokenId, activationId);
 
-                // Remove a token, ignore response, since the endpoint should quietly return
-                powerAuthClient.removeToken(tokenId, activationId);
-
-                // Prepare a response
-                final TokenRemoveResponse response = new TokenRemoveResponse();
-                response.setTokenId(tokenId);
-                return response;
-
-            } else {
-                throw new PowerAuthAuthenticationException();
-            }
-        } catch (PowerAuthAuthenticationException ex) {
-            throw ex;
+            // Prepare a response
+            final TokenRemoveResponse response = new TokenRemoveResponse();
+            response.setTokenId(tokenId);
+            return response;
         } catch (Exception ex) {
             logger.warn("Removing PowerAuth token failed", ex);
             throw new PowerAuthAuthenticationException(ex.getMessage());

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
@@ -1,0 +1,140 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.spring.service.v3;
+
+import io.getlime.powerauth.soap.v3.CreateTokenResponse;
+import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
+import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
+import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import io.getlime.security.powerauth.rest.api.model.response.v3.TokenRemoveResponse;
+import io.getlime.security.powerauth.rest.api.spring.converter.v3.SignatureTypeConverter;
+import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * Service implementing token functionality.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>3.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Service("TokenServiceV3")
+public class TokenService {
+
+    private static final Logger logger = LoggerFactory.getLogger(TokenService.class);
+
+    private PowerAuthServiceClient powerAuthClient;
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    /**
+     * Create token.
+     * @param request ECIES encrypted create token request.
+     * @param authentication PowerAuth API authentication object.
+     * @return ECIES encrypted create token response.
+     * @throws PowerAuthAuthenticationException In case token could not be created.
+     */
+    public EciesEncryptedResponse createToken(@RequestBody EciesEncryptedRequest request,
+                                              PowerAuthApiAuthentication authentication)
+            throws PowerAuthAuthenticationException {
+        try {
+
+                // Fetch activation ID and signature type
+                final PowerAuthSignatureTypes signatureFactors = authentication.getSignatureFactors();
+
+                // Fetch data from the request
+                final String ephemeralPublicKey = request.getEphemeralPublicKey();
+                final String encryptedData = request.getEncryptedData();
+                final String mac = request.getMac();
+
+                // Prepare a signature type converter
+                SignatureTypeConverter converter = new SignatureTypeConverter();
+
+                // Get ECIES headers
+                String activationId = authentication.getActivationId();
+                PowerAuthSignatureHttpHeader httpHeader = (PowerAuthSignatureHttpHeader) authentication.getHttpHeader();
+                String applicationKey = httpHeader.getApplicationKey();
+
+                // Create a token
+                final CreateTokenResponse token = powerAuthClient.createToken(activationId, applicationKey, ephemeralPublicKey,
+                        encryptedData, mac, converter.convertFrom(signatureFactors));
+
+                // Prepare a response
+                final EciesEncryptedResponse response = new EciesEncryptedResponse();
+                response.setMac(token.getMac());
+                response.setEncryptedData(token.getEncryptedData());
+                return response;
+        } catch (Exception ex) {
+            logger.warn("Creating PowerAuth token failed", ex);
+            throw new PowerAuthAuthenticationException(ex.getMessage());
+        }
+    }
+
+    /**
+     * Remove token.
+     * @param request Remove token request.
+     * @param authentication PowerAuth API authentication object.
+     * @return Remove token response.
+     * @throws PowerAuthAuthenticationException In case authentication fails.
+     */
+    public TokenRemoveResponse removeToken(TokenRemoveRequest request, PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
+        try {
+            if (authentication != null && authentication.getActivationId() != null) {
+
+                // Fetch activation ID
+                final String activationId = authentication.getActivationId();
+
+                // Fetch token ID from the request
+                final String tokenId = request.getTokenId();
+
+                // Remove a token, ignore response, since the endpoint should quietly return
+                powerAuthClient.removeToken(tokenId, activationId);
+
+                // Prepare a response
+                final TokenRemoveResponse response = new TokenRemoveResponse();
+                response.setTokenId(tokenId);
+                return response;
+
+            } else {
+                throw new PowerAuthAuthenticationException();
+            }
+        }  catch (PowerAuthAuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            logger.warn("Removing PowerAuth token failed", ex);
+            throw new PowerAuthAuthenticationException(ex.getMessage());
+        }
+    }
+}

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
@@ -57,7 +57,6 @@ import java.util.List;
 @Service("UpgradeServiceV3")
 public class UpgradeService {
 
-
     private static final Logger logger = LoggerFactory.getLogger(UpgradeService.class);
 
     private PowerAuthServiceClient powerAuthClient;

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
@@ -1,0 +1,160 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.spring.service.v3;
+
+import io.getlime.core.rest.model.base.response.Response;
+import io.getlime.powerauth.soap.v3.CommitUpgradeResponse;
+import io.getlime.powerauth.soap.v3.StartUpgradeResponse;
+import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import io.getlime.security.powerauth.http.PowerAuthEncryptionHttpHeader;
+import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
+import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthUpgradeException;
+import io.getlime.security.powerauth.rest.api.base.filter.PowerAuthRequestFilterBase;
+import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
+import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
+import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import io.getlime.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
+import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Service implementing upgrade functionality.
+ *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>3.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Service("UpgradeServiceV3")
+public class UpgradeService {
+
+
+    private static final Logger logger = LoggerFactory.getLogger(UpgradeService.class);
+
+    private PowerAuthServiceClient powerAuthClient;
+    private PowerAuthAuthenticationProvider authenticationProvider;
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthServiceClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    @Autowired
+    public void setAuthenticationProvider(PowerAuthAuthenticationProvider authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
+    }
+
+    /**
+     * Start upgrade of activation to version 3.
+     * @param request ECIES encrypted upgrade start request.
+     * @param header PowerAuth encryption HTTP header.
+     * @return ECIES encrypted upgrade activation response.
+     * @throws PowerAuthUpgradeException In case upgrade start fails.
+     */
+    public EciesEncryptedResponse upgradeStart(EciesEncryptedRequest request, PowerAuthEncryptionHttpHeader header)
+            throws PowerAuthUpgradeException {
+
+        try {
+            // Fetch data from the request
+            final String ephemeralPublicKey = request.getEphemeralPublicKey();
+            final String encryptedData = request.getEncryptedData();
+            final String mac = request.getMac();
+
+            // Get ECIES headers
+            final String activationId = header.getActivationId();
+            final String applicationKey = header.getApplicationKey();
+
+            // Start upgrade on PowerAuth server
+            StartUpgradeResponse upgradeResponse = powerAuthClient.startUpgrade(activationId, applicationKey, ephemeralPublicKey, encryptedData, mac);
+
+            // Prepare a response
+            final EciesEncryptedResponse response = new EciesEncryptedResponse();
+            response.setMac(upgradeResponse.getMac());
+            response.setEncryptedData(upgradeResponse.getEncryptedData());
+            return response;
+        } catch (Exception ex) {
+            logger.warn("PowerAuth upgrade start failed", ex);
+            throw new PowerAuthUpgradeException();
+        }
+    }
+
+    /**
+     * Commit upgrade of activation to version 3.
+     * @param signatureHeader PowerAuth signature HTTP header.
+     * @param httpServletRequest HTTP servlet request.
+     * @return Commit upgrade response.
+     * @throws PowerAuthAuthenticationException in case authentication fails.
+     * @throws PowerAuthUpgradeException In case upgrade commit fails.
+     */
+    public Response upgradeCommit(String signatureHeader,
+                                  HttpServletRequest httpServletRequest)
+            throws PowerAuthAuthenticationException, PowerAuthUpgradeException {
+
+        try {
+            // Extract request body
+            PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) httpServletRequest.getAttribute(PowerAuthRequestFilterBase.POWERAUTH_REQUEST_BODY));
+            byte[] requestBodyBytes = requestBody.getRequestBytes();
+            if (requestBodyBytes == null || requestBodyBytes.length == 0) {
+                // Expected request body is {}, do not accept empty body
+                throw new PowerAuthAuthenticationException();
+            }
+
+            // Verify signature, force signature version during upgrade to version 3
+            List<PowerAuthSignatureTypes> allowedSignatureTypes = Collections.singletonList(PowerAuthSignatureTypes.POSSESSION);
+            PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/upgrade/commit", signatureHeader, allowedSignatureTypes, 3);
+
+            // In case signature verification fails, upgrade fails, too
+            if (authentication == null || authentication.getActivationId() == null) {
+                throw new PowerAuthAuthenticationException();
+            }
+
+            // Get signature HTTP headers
+            final String activationId = authentication.getActivationId();
+            final PowerAuthSignatureHttpHeader httpHeader = (PowerAuthSignatureHttpHeader) authentication.getHttpHeader();
+            final String applicationKey = httpHeader.getApplicationKey();
+
+            // Commit upgrade on PowerAuth server
+            CommitUpgradeResponse upgradeResponse = powerAuthClient.commitUpgrade(activationId, applicationKey);
+
+            if (upgradeResponse.isCommitted()) {
+                return new Response();
+            } else {
+                throw new PowerAuthUpgradeException();
+            }
+        } catch (PowerAuthAuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            logger.warn("PowerAuth upgrade commit failed", ex);
+            throw new PowerAuthUpgradeException();
+        }
+    }
+}


### PR DESCRIPTION
This pull request moves controller code in restful-integration into services.

This was done to:
- get rid of duplicated code (e.g. activation status, activation remove, token remove, etc.)
- separate business logic and make the code easier to read