### PR TITLE
Fix #125: Missing request versioning based on protocol version for vault unlock in Java EE

### DIFF
--- a/powerauth-restful-security-javaee/pom.xml
+++ b/powerauth-restful-security-javaee/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-restful-security-javaee</artifactId>
-    <version>0.19.0</version>
+    <version>0.19.1</version>
     <name>powerauth-restful-security-javaee</name>
     <description>PowerAuth 2.0 RESTful API Security Additions for EJB</description>
 
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-client-axis</artifactId>
-            <version>0.19.0</version>
+            <version>0.19.1</version>
         </dependency>
 
     </dependencies>

--- a/powerauth-restful-server-javaee/pom.xml
+++ b/powerauth-restful-server-javaee/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>powerauth-restful-server-javaee</artifactId>
     <name>powerauth-restful-server-javaee</name>
     <packaging>war</packaging>
-    <version>0.19.0</version>
+    <version>0.19.1</version>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-javaee</artifactId>
-            <version>0.19.0</version>
+            <version>0.19.1</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This pull request contains following changes:
- Fix #125: Missing request versioning based on protocol version for vault unlock in Java EE
- Increase powerauth-java-client-axis project version due to backport of fix of WSDL in version 0.19.1
- Increase powerauth-restful-server-javaee project version for hotfix release 0.19.1