### PR TITLE
Fix #140: Support for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>io.getlime.security</groupId>
     <artifactId>powerauth-restful-integration-parent</artifactId>
-    <version>0.21.0</version>
+    <version>0.22.0</version>
     <packaging>pom</packaging>
 
     <inceptionYear>2017</inceptionYear>
@@ -87,12 +87,11 @@
         <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
         <javaee-api.version>7.0</javaee-api.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <spring-boot.version>2.0.8.RELEASE</spring-boot.version>
-        <spring-security.version>3.0.4.RELEASE</spring-security.version>
+        <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
         <guava.version>27.0.1-jre</guava.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <jackson-databind.version>2.9.8</jackson-databind.version>
-        <bcprov.version>1.60</bcprov.version>
+        <bcprov.version>1.61</bcprov.version>
         <rest-model-base.version>1.1.0</rest-model-base.version>
     </properties>
 

--- a/powerauth-restful-model/pom.xml
+++ b/powerauth-restful-model/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-restful-model</artifactId>
-    <version>0.21.0</version>
+    <version>0.22.0</version>
     <name>powerauth-restful-model</name>
     <description>Model classes PowerAuth Standard RESTful API</description>
 
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-restful-integration-parent</artifactId>
-        <version>0.21.0</version>
+        <version>0.22.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/powerauth-restful-security-base/pom.xml
+++ b/powerauth-restful-security-base/pom.xml
@@ -25,12 +25,12 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powerauth-restful-security-base</artifactId>
-    <version>0.21.0</version>
+    <version>0.22.0</version>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.21.0</version>
+        <version>0.22.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -40,17 +40,17 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-crypto</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-http</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-model</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
 
         <!-- Other Dependencies -->

--- a/powerauth-restful-security-javaee/pom.xml
+++ b/powerauth-restful-security-javaee/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-restful-security-javaee</artifactId>
-    <version>0.21.0</version>
+    <version>0.22.0</version>
     <name>powerauth-restful-security-javaee</name>
     <description>PowerAuth RESTful API Security Additions for EJB</description>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.21.0</version>
+        <version>0.22.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-base</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-client-axis</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/powerauth-restful-security-spring/pom.xml
+++ b/powerauth-restful-security-spring/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-restful-security-spring</artifactId>
-    <version>0.21.0</version>
+    <version>0.22.0</version>
     <name>powerauth-restful-security-spring</name>
     <description>PowerAuth RESTful API Security Additions for Spring</description>
 
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-restful-integration-parent</artifactId>
-        <version>0.21.0</version>
+        <version>0.22.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -53,12 +53,12 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-base</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-client-spring</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
 
     </dependencies>

--- a/powerauth-restful-server-javaee/pom.xml
+++ b/powerauth-restful-server-javaee/pom.xml
@@ -27,12 +27,12 @@
     <artifactId>powerauth-restful-server-javaee</artifactId>
     <name>powerauth-restful-server-javaee</name>
     <packaging>war</packaging>
-    <version>0.21.0</version>
+    <version>0.22.0</version>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.21.0</version>
+        <version>0.22.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -46,12 +46,13 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-javaee</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
             <version>${bcprov.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/powerauth-restful-server-spring/pom.xml
+++ b/powerauth-restful-server-spring/pom.xml
@@ -26,14 +26,14 @@
     <name>powerauth-restful-server-spring</name>
     <description>PowerAuth Standard RESTful API</description>
     <artifactId>powerauth-restful-server-spring</artifactId>
-    <version>0.21.0</version>
+    <version>0.22.0</version>
     <packaging>war</packaging>
 
     <parent>
-        <groupId>io.getlime.security</groupId>
-        <artifactId>powerauth-restful-integration-parent</artifactId>
-        <version>0.21.0</version>
-        <relativePath>../pom.xml</relativePath>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.1.2.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <dependencies>
@@ -42,27 +42,20 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
-            <version>${spring-boot.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-ws-security</artifactId>
-            <version>${spring-security.version}</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>ehcache</artifactId>
-                    <groupId>net.sf.ehcache</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>geronimo-javamail_1.4_mail</artifactId>
-                    <groupId>org.apache.geronimo.javamail</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                    <groupId>org.bouncycastle</groupId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -71,19 +64,47 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-spring</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
 
         <!-- Other Dependencies -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>${bcprov.version}</version>
+            <version>1.61</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Dependencies for Java 11 -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
+            <version>3.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>javax.xml.soap-api</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
+            <version>1.5.1</version>
         </dependency>
 
     </dependencies>
@@ -93,7 +114,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <id>build-info</id>
@@ -106,7 +126,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven-deploy-plugin.version}</version>
+                <version>2.8.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
This pull request contains following changes:
- Fix #140: Support for Java 11
- Update version to 0.22.0
- Updated BC dependency
- Spring boot dependency updated to 2.1.2.RELEASE
- Use spring-boot-starter-parent as parent of powerauth-restful-server-spring to avoid compatibility issues in Spring dependencies, do not specify spring-security version