### PR TITLE
Fix #107: Customization of expiration and maximum failure count in custom activations

### DIFF
--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/CustomActivationProvider.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/CustomActivationProvider.java
@@ -69,16 +69,22 @@ public interface CustomActivationProvider {
      * Get maximum failed attempt count for activations.
      * Use null value for using value which is configured on PowerAuth server.
      *
+     * @param identityAttributes Identity related attributes.
+     * @param customAttributes Custom attributes, not related to identity.
+     * @param userId User ID of user who created the activation.
      * @return Maximum failed attempt count for activations.
      */
-    Integer getMaxFailedAttemptCount();
+    Integer getMaxFailedAttemptCount(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String userId);
 
     /**
      * Get length of the period of activation record validity during activation in milliseconds.
      * Use null value for using value which is configured on PowerAuth server.
      *
+     * @param identityAttributes Identity related attributes.
+     * @param customAttributes Custom attributes, not related to identity.
+     * @param userId User ID of user who created the activation.
      * @return Period in milliseconds during which activation is valid before it expires.
      */
-    Integer getValidityPeriodDuringActivation();
+    Integer getValidityPeriodDuringActivation(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String userId);
 
 }

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/CustomActivationProvider.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/CustomActivationProvider.java
@@ -29,11 +29,13 @@ import java.util.Map;
  * of auto-commit mode.
  *
  * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  */
 public interface CustomActivationProvider {
 
     /**
      * This method is responsible for looking user ID up based on a provided set of identity attributes.
+     *
      * @param identityAttributes Attributes that uniquely identify user with given ID.
      * @return User ID value.
      */
@@ -41,6 +43,7 @@ public interface CustomActivationProvider {
 
     /**
      * Process custom attributes, in any way that is suitable for the purpose of your application.
+     *
      * @param customAttributes Custom attributes (not related to identity) to be processed.
      * @param activationId Activation ID of created activation.
      * @param userId User ID of user who created the activation.
@@ -62,5 +65,20 @@ public interface CustomActivationProvider {
      */
     boolean shouldAutoCommitActivation(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String activationId, String userId);
 
+    /**
+     * Get maximum failed attempt count for activations.
+     * Use null value for using value which is configured on PowerAuth server.
+     *
+     * @return Maximum failed attempt count for activations.
+     */
+    Integer getMaxFailedAttemptCount();
+
+    /**
+     * Get length of the period of activation record validity during activation in milliseconds.
+     * Use null value for using value which is configured on PowerAuth server.
+     *
+     * @return Period in milliseconds during which activation is valid before it expires.
+     */
+    Integer getValidityPeriodDuringActivation();
 
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
@@ -131,8 +131,9 @@ public class ActivationService {
                     }
 
                     // Resolve maxFailedCount and activationExpireTimestamp parameters, null value means use value configured on PowerAuth server
-                    final Long maxFailedCount = activationProvider.getMaxFailedAttemptCount() == null ? null : activationProvider.getMaxFailedAttemptCount().longValue();
-                    final Integer activationValidityPeriod = activationProvider.getValidityPeriodDuringActivation();
+                    Integer maxFailed = activationProvider.getMaxFailedAttemptCount(identity, customAttributes, userId);
+                    final Long maxFailedCount = maxFailed == null ? null : maxFailed.longValue();
+                    final Integer activationValidityPeriod = activationProvider.getValidityPeriodDuringActivation(identity, customAttributes, userId);
                     Date activationExpireTimestamp = null;
                     if (activationValidityPeriod != null) {
                         Calendar activationExpiration = GregorianCalendar.getInstance();

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
@@ -40,6 +40,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Map;
 
 /**
@@ -127,11 +130,21 @@ public class ActivationService {
                         throw new PowerAuthActivationException();
                     }
 
+                    // Resolve maxFailedCount and activationExpireTimestamp parameters, null value means use value configured on PowerAuth server
+                    final Long maxFailedCount = activationProvider.getMaxFailedAttemptCount() == null ? null : activationProvider.getMaxFailedAttemptCount().longValue();
+                    final Integer activationValidityPeriod = activationProvider.getValidityPeriodDuringActivation();
+                    Date activationExpireTimestamp = null;
+                    if (activationValidityPeriod != null) {
+                        Calendar activationExpiration = GregorianCalendar.getInstance();
+                        activationExpiration.add(Calendar.MILLISECOND, activationValidityPeriod);
+                        activationExpireTimestamp = activationExpiration.getTime();
+                    }
+
                     // Create activation for a looked up user and application related to the given application key
                     PowerAuthPortV3ServiceStub.CreateActivationResponse response = powerAuthClient.createActivation(
                             userId,
-                            null,
-                            null,
+                            activationExpireTimestamp,
+                            maxFailedCount,
                             applicationKey,
                             ephemeralPublicKey,
                             encryptedData,

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/exception/PowerAuthExceptionHandler.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/exception/PowerAuthExceptionHandler.java
@@ -21,7 +21,6 @@ package io.getlime.security.powerauth.rest.api.spring.exception;
 
 import io.getlime.core.rest.model.base.response.ErrorResponse;
 import io.getlime.security.powerauth.rest.api.base.exception.*;
-import io.getlime.security.powerauth.rest.api.spring.controller.v3.UpgradeController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
@@ -43,7 +42,7 @@ public class PowerAuthExceptionHandler {
 
     public static final int PRECEDENCE = -100;
 
-    private static final Logger logger = LoggerFactory.getLogger(UpgradeController.class);
+    private static final Logger logger = LoggerFactory.getLogger(PowerAuthExceptionHandler.class);
 
     /**
      * Handle PowerAuthAuthenticationException exceptions.

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
@@ -146,8 +146,9 @@ public class ActivationService {
                     }
 
                     // Resolve maxFailedCount and activationExpireTimestamp parameters, null value means use value configured on PowerAuth server
-                    final Long maxFailedCount = activationProvider.getMaxFailedAttemptCount() == null ? null : activationProvider.getMaxFailedAttemptCount().longValue();
-                    final Integer activationValidityPeriod = activationProvider.getValidityPeriodDuringActivation();
+                    Integer maxFailed = activationProvider.getMaxFailedAttemptCount(identity, customAttributes, userId);
+                    final Long maxFailedCount = maxFailed == null ? null : maxFailed.longValue();
+                    final Integer activationValidityPeriod = activationProvider.getValidityPeriodDuringActivation(identity, customAttributes, userId);
                     Date activationExpireTimestamp = null;
                     if (activationValidityPeriod != null) {
                         Calendar activationExpiration = GregorianCalendar.getInstance();

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/provider/DefaultCustomActivationProvider.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/provider/DefaultCustomActivationProvider.java
@@ -19,6 +19,7 @@
  */
 package io.getlime.security.powerauth.app.rest.api.javaee.provider;
 
+import io.getlime.security.powerauth.rest.api.base.provider.CustomActivationProvider;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
 
 import java.util.Collections;
@@ -28,7 +29,7 @@ import java.util.Map;
 /**
  * @author Petr Dvorak, petr@wultra.com
  */
-public class CustomActivationProvider implements io.getlime.security.powerauth.rest.api.base.provider.CustomActivationProvider {
+public class DefaultCustomActivationProvider implements CustomActivationProvider {
 
     @Override
     public String lookupUserIdForAttributes(Map<String, String> identityAttributes) {
@@ -48,5 +49,17 @@ public class CustomActivationProvider implements io.getlime.security.powerauth.r
     @Override
     public boolean shouldAutoCommitActivation(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String activationId, String userId) {
         return true;
+    }
+
+    @Override
+    public Integer getMaxFailedAttemptCount() {
+        // Null value means use value configured on PowerAuth server
+        return null;
+    }
+
+    @Override
+    public Integer getValidityPeriodDuringActivation() {
+        // Null value means use value configured on PowerAuth server
+        return null;
     }
 }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/provider/DefaultCustomActivationProvider.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/provider/DefaultCustomActivationProvider.java
@@ -52,13 +52,13 @@ public class DefaultCustomActivationProvider implements CustomActivationProvider
     }
 
     @Override
-    public Integer getMaxFailedAttemptCount() {
+    public Integer getMaxFailedAttemptCount(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String userId) {
         // Null value means use value configured on PowerAuth server
         return null;
     }
 
     @Override
-    public Integer getValidityPeriodDuringActivation() {
+    public Integer getValidityPeriodDuringActivation(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String userId) {
         // Null value means use value configured on PowerAuth server
         return null;
     }

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/provider/DefaultCustomActivationProvider.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/provider/DefaultCustomActivationProvider.java
@@ -54,4 +54,16 @@ public class DefaultCustomActivationProvider implements CustomActivationProvider
     public boolean shouldAutoCommitActivation(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String activationId, String userId) {
         return true;
     }
+
+    @Override
+    public Integer getMaxFailedAttemptCount() {
+        // Null value means use value configured on PowerAuth server
+        return null;
+    }
+
+    @Override
+    public Integer getValidityPeriodDuringActivation() {
+        // Null value means use value configured on PowerAuth server
+        return null;
+    }
 }

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/provider/DefaultCustomActivationProvider.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/provider/DefaultCustomActivationProvider.java
@@ -56,13 +56,13 @@ public class DefaultCustomActivationProvider implements CustomActivationProvider
     }
 
     @Override
-    public Integer getMaxFailedAttemptCount() {
+    public Integer getMaxFailedAttemptCount(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String userId) {
         // Null value means use value configured on PowerAuth server
         return null;
     }
 
     @Override
-    public Integer getValidityPeriodDuringActivation() {
+    public Integer getValidityPeriodDuringActivation(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String userId) {
         // Null value means use value configured on PowerAuth server
         return null;
     }


### PR DESCRIPTION
This pull request contains following changes:
- Fix #107: Customization of expiration and maximum failure count in custom activations
- Fixed class used in logging
- Renamed CustomActivationProvider in javaee due to class name clash