### PR TITLE
Fix #162: Resolve advisories reported by OWASP check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
         <javaee-api.version>7.0</javaee-api.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <spring-boot.version>2.1.4.RELEASE</spring-boot.version>
+        <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
         <guava.version>27.0.1-jre</guava.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <jackson-databind.version>2.9.8</jackson-databind.version>

--- a/powerauth-restful-server-spring/pom.xml
+++ b/powerauth-restful-server-spring/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.4.RELEASE</version>
+        <version>2.1.5.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -56,6 +56,14 @@
                 <exclusion>
                     <artifactId>bcprov-jdk15on</artifactId>
                     <groupId>org.bouncycastle</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>ehcache</artifactId>
+                    <groupId>net.sf.ehcache</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>geronimo-javamail_1.4_mail</artifactId>
+                    <groupId>org.apache.geronimo.javamail</groupId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
The resolution is:
- `tomcat-embed-core` is upgraded transitively by upgrading `spring-boot-starter-parent`
- `ehcache` is excluded as in previous release
- `geronimo-javamail` is excluded as in previous release
- issues in Spring boot security are related to Spring Framework `5.0.5`, see: https://pivotal.io/security/cve-2018-1258
- `axis2` is already in most recent version, dependency cannot be upgraded
- `jackson-databind` upgrade is risky, there is no version of `Spring Boot` released with fixed version, moreover the advisory does not apply to current usage (it requires `default typing` enabled and is only applicable to `MySQL`)