### PR TITLE
Fix #182: Added support for V3.1 signatures

### DIFF
--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
@@ -121,7 +121,7 @@ public class ActivationController {
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
             throw new PowerAuthAuthenticationException("Signature validation failed");
         }
-        if (!"3.0".equals(apiAuthentication.getVersion())) {
+        if (!"3.0".equals(apiAuthentication.getVersion()) && !"3.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
             throw new PowerAuthAuthenticationException();
         }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/RecoveryController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/RecoveryController.java
@@ -89,7 +89,7 @@ public class RecoveryController {
                         PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE
                 ));
         if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion())) {
+            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                 throw new PowerAuthAuthenticationException();
             }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SecureVaultController.java
@@ -85,7 +85,7 @@ public class SecureVaultController {
             throw new PowerAuthAuthenticationException(ex.getMessage());
         }
 
-        if (!"3.0".equals(header.getVersion())) {
+        if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
             throw new PowerAuthAuthenticationException();
         }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
@@ -121,7 +121,7 @@ public class SignatureController {
                     )
             );
             if (authentication != null && authentication.getActivationId() != null) {
-                if (!"3.0".equals(authentication.getVersion())) {
+                if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                     logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                     throw new PowerAuthAuthenticationException();
                 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/TokenController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/TokenController.java
@@ -84,7 +84,7 @@ public class TokenController {
                         PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
                 ));
         if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion())) {
+            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                 throw new PowerAuthAuthenticationException();
             }
@@ -117,7 +117,7 @@ public class TokenController {
                 ));
 
         if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion())) {
+            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                 throw new PowerAuthAuthenticationException();
             }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
@@ -92,7 +92,7 @@ public class UpgradeController {
             throw new PowerAuthUpgradeException(ex.getMessage());
         }
 
-        if (!"3.0".equals(header.getVersion())) {
+        if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
             throw new PowerAuthUpgradeException();
         }
@@ -124,7 +124,7 @@ public class UpgradeController {
             throw new PowerAuthUpgradeException(ex.getMessage());
         }
 
-        if (!"3.0".equals(header.getVersion())) {
+        if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
             throw new PowerAuthAuthenticationException();
         }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
@@ -91,6 +91,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             soapRequest.setApplicationKey(authentication.getApplicationKey());
             soapRequest.setSignature(authentication.getSignature());
             soapRequest.setSignatureType(signatureType);
+            soapRequest.setSignatureVersion(authentication.getVersion());
             soapRequest.setData(PowerAuthHttpBody.getSignatureBaseString(
                     authentication.getHttpMethod(),
                     authentication.getRequestUri(),

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
@@ -78,6 +78,7 @@ public class SecureVaultService {
             String applicationKey = header.getApplicationKey();
             String signature = header.getSignature();
             PowerAuthPortV3ServiceStub.SignatureType signatureType = converter.convertFrom(header.getSignatureType());
+            String signatureVersion = header.getVersion();
             String nonce = header.getNonce();
 
             // Fetch data from the request
@@ -91,7 +92,7 @@ public class SecureVaultService {
 
             // Verify signature and get encrypted vault encryption key from PowerAuth server
             PowerAuthPortV3ServiceStub.VaultUnlockResponse soapResponse = powerAuthClient.unlockVault(activationId, applicationKey, signature,
-                    signatureType, data, ephemeralPublicKey, encryptedData, mac);
+                    signatureType, signatureVersion, data, ephemeralPublicKey, encryptedData, mac);
 
             if (!soapResponse.getSignatureValid()) {
                 throw new PowerAuthAuthenticationException();

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
@@ -107,6 +107,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             soapRequest.setApplicationKey(authentication.getApplicationKey());
             soapRequest.setSignature(authentication.getSignature());
             soapRequest.setSignatureType(signatureType);
+            soapRequest.setSignatureVersion(authentication.getVersion());
             soapRequest.setData(PowerAuthHttpBody.getSignatureBaseString(
                     authentication.getHttpMethod(),
                     authentication.getRequestUri(),

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
@@ -128,7 +128,7 @@ public class ActivationController {
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
             throw new PowerAuthAuthenticationException("Signature validation failed");
         }
-        if (!"3.0".equals(apiAuthentication.getVersion())) {
+        if (!"3.0".equals(apiAuthentication.getVersion()) && !"3.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
             throw new PowerAuthAuthenticationException();
         }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/RecoveryController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/RecoveryController.java
@@ -79,7 +79,7 @@ public class RecoveryController {
             throw new PowerAuthAuthenticationException();
         }
         if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion())) {
+            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                 throw new PowerAuthAuthenticationException();
             }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
@@ -90,7 +90,7 @@ public class SecureVaultController {
             throw new PowerAuthAuthenticationException(ex.getMessage());
         }
 
-        if (!"3.0".equals(header.getVersion())) {
+        if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
             throw new PowerAuthAuthenticationException();
         }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
@@ -62,7 +62,7 @@ public class SignatureController {
     public Response validateSignature(PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
 
         if (auth != null && auth.getActivationId() != null) {
-            if (!"3.0".equals(auth.getVersion())) {
+            if (!"3.0".equals(auth.getVersion()) && !"3.1".equals(auth.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
                 throw new PowerAuthAuthenticationException();
             }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
@@ -83,7 +83,7 @@ public class TokenController {
             throw new PowerAuthAuthenticationException();
         }
         if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion())) {
+            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                 throw new PowerAuthAuthenticationException();
             }
@@ -114,7 +114,7 @@ public class TokenController {
             throw new PowerAuthAuthenticationException();
         }
         if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion())) {
+            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
                 throw new PowerAuthAuthenticationException();
             }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
@@ -88,7 +88,7 @@ public class UpgradeController {
             throw new PowerAuthUpgradeException(ex.getMessage());
         }
 
-        if (!"3.0".equals(header.getVersion())) {
+        if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
             throw new PowerAuthUpgradeException();
         }
@@ -121,7 +121,7 @@ public class UpgradeController {
             throw new PowerAuthUpgradeException(ex.getMessage());
         }
 
-        if (!"3.0".equals(header.getVersion())) {
+        if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
             throw new PowerAuthAuthenticationException();
         }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/SecureVaultService.java
@@ -87,6 +87,7 @@ public class SecureVaultService {
             String applicationKey = header.getApplicationKey();
             String signature = header.getSignature();
             SignatureType signatureType = converter.convertFrom(header.getSignatureType());
+            String signatureVersion = header.getVersion();
             String nonce = header.getNonce();
 
             // Fetch data from the request
@@ -100,7 +101,7 @@ public class SecureVaultService {
 
             // Verify signature and get encrypted vault encryption key from PowerAuth server
             VaultUnlockResponse soapResponse = powerAuthClient.unlockVault(activationId, applicationKey, signature,
-                    signatureType, data, ephemeralPublicKey, encryptedData, mac);
+                    signatureType, signatureVersion, data, ephemeralPublicKey, encryptedData, mac);
 
             if (!soapResponse.isSignatureValid()) {
                 throw new PowerAuthAuthenticationException();


### PR DESCRIPTION
This change is all about passing version of signature into the PowerAuth client interface.