### PR TITLE
Fix #230: Improve logic for unknown signature type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>io.getlime.security</groupId>
     <artifactId>powerauth-restful-integration-parent</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <inceptionYear>2017</inceptionYear>

--- a/powerauth-restful-model/pom.xml
+++ b/powerauth-restful-model/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-restful-model</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <name>powerauth-restful-model</name>
     <description>Model classes PowerAuth Standard RESTful API</description>
 
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-restful-integration-parent</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/powerauth-restful-security-base/pom.xml
+++ b/powerauth-restful-security-base/pom.xml
@@ -25,12 +25,12 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powerauth-restful-security-base</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.24.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -40,17 +40,17 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-crypto</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-http</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-model</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Other Dependencies -->

--- a/powerauth-restful-security-javaee/pom.xml
+++ b/powerauth-restful-security-javaee/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-restful-security-javaee</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <name>powerauth-restful-security-javaee</name>
     <description>PowerAuth RESTful API Security Additions for EJB</description>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.24.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-base</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-client-axis</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v2/SignatureTypeConverter.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v2/SignatureTypeConverter.java
@@ -38,9 +38,9 @@ public class SignatureTypeConverter {
      */
     public PowerAuthPortV2ServiceStub.SignatureType convertFrom(String signatureTypeString) {
 
-        // Default to strongest signature type on null value
+        // Return null value which represents an unknown signature type
         if (signatureTypeString == null) {
-            return PowerAuthPortV2ServiceStub.SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+            return null;
         }
 
         // Try to convert signature type
@@ -48,7 +48,8 @@ public class SignatureTypeConverter {
             signatureTypeString = signatureTypeString.toUpperCase();
             return PowerAuthPortV2ServiceStub.SignatureType.Factory.fromValue(signatureTypeString);
         } catch (IllegalArgumentException e) {
-            return PowerAuthPortV2ServiceStub.SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+            // Return null value which represents an unknown signature type
+            return null;
         }
 
     }
@@ -60,6 +61,9 @@ public class SignatureTypeConverter {
      * @return Signature type.
      */
     public PowerAuthPortV2ServiceStub.SignatureType convertFrom(PowerAuthSignatureTypes powerAuthSignatureTypes) {
+        if (powerAuthSignatureTypes == null) {
+            return null;
+        }
         switch (powerAuthSignatureTypes) {
             case POSSESSION:
                 return PowerAuthPortV2ServiceStub.SignatureType.POSSESSION;

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v2/SignatureTypeConverter.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v2/SignatureTypeConverter.java
@@ -76,7 +76,7 @@ public class SignatureTypeConverter {
             case POSSESSION_BIOMETRY:
                 return PowerAuthPortV2ServiceStub.SignatureType.POSSESSION_BIOMETRY;
             default:
-                return PowerAuthPortV2ServiceStub.SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+                return null;
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v3/SignatureTypeConverter.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v3/SignatureTypeConverter.java
@@ -38,9 +38,9 @@ public class SignatureTypeConverter {
      */
     public PowerAuthPortV3ServiceStub.SignatureType convertFrom(String signatureTypeString) {
 
-        // Default to strongest signature type on null value
+        // Return null value which represents an unknown signature type
         if (signatureTypeString == null) {
-            return PowerAuthPortV3ServiceStub.SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+            return null;
         }
 
         // Try to convert signature type
@@ -48,7 +48,8 @@ public class SignatureTypeConverter {
             signatureTypeString = signatureTypeString.toUpperCase();
             return PowerAuthPortV3ServiceStub.SignatureType.Factory.fromValue(signatureTypeString);
         } catch (IllegalArgumentException e) {
-            return PowerAuthPortV3ServiceStub.SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+            // Return null value which represents an unknown signature type
+            return null;
         }
 
     }
@@ -60,6 +61,9 @@ public class SignatureTypeConverter {
      * @return Signature type.
      */
     public PowerAuthPortV3ServiceStub.SignatureType convertFrom(PowerAuthSignatureTypes powerAuthSignatureTypes) {
+        if (powerAuthSignatureTypes == null) {
+            return null;
+        }
         switch (powerAuthSignatureTypes) {
             case POSSESSION:
                 return PowerAuthPortV3ServiceStub.SignatureType.POSSESSION;
@@ -72,7 +76,7 @@ public class SignatureTypeConverter {
             case POSSESSION_BIOMETRY:
                 return PowerAuthPortV3ServiceStub.SignatureType.POSSESSION_BIOMETRY;
             default:
-                return PowerAuthPortV3ServiceStub.SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+                return null;
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
@@ -65,7 +65,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
     public PowerAuthAuthenticationProvider() {
     }
 
-    public PowerAuthApiAuthentication authenticate(PowerAuthAuthentication authentication) throws RemoteException {
+    public PowerAuthApiAuthentication authenticate(PowerAuthAuthentication authentication) throws PowerAuthAuthenticationException, RemoteException {
         // Handle signature based authentications
         if (authentication instanceof PowerAuthSignatureAuthentication) {
             return validateSignatureAuthentication((PowerAuthSignatureAuthentication) authentication);
@@ -83,12 +83,17 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
      *
      * @param authentication Signature based authentication object.
      * @return API authentication object in case of successful authentication, null otherwise.
+     * @throws PowerAuthAuthenticationException In case signature type is invalid.
+     * @throws RemoteException In case remote communication fails.
      */
-    private PowerAuthApiAuthentication validateSignatureAuthentication(PowerAuthSignatureAuthentication authentication) throws RemoteException {
+    private PowerAuthApiAuthentication validateSignatureAuthentication(PowerAuthSignatureAuthentication authentication) throws PowerAuthAuthenticationException, RemoteException {
         if (authentication.getSignatureType() != null) {
 
             SignatureTypeConverter converter = new SignatureTypeConverter();
             final PowerAuthPortV3ServiceStub.SignatureType signatureType = converter.convertFrom(authentication.getSignatureType());
+            if (signatureType == null) {
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+            }
 
             PowerAuthPortV3ServiceStub.VerifySignatureRequest soapRequest = new PowerAuthPortV3ServiceStub.VerifySignatureRequest();
             soapRequest.setActivationId(authentication.getActivationId());

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
@@ -216,7 +216,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
 
         // Check if the signature type is allowed
         PowerAuthSignatureTypes expectedSignatureType = PowerAuthSignatureTypes.getEnumFromString(header.getSignatureType());
-        if (!allowedSignatureTypes.contains(expectedSignatureType)) {
+        if (expectedSignatureType == null || !allowedSignatureTypes.contains(expectedSignatureType)) {
             throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
         }
 
@@ -293,7 +293,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
 
         // Check if the signature type is allowed
         PowerAuthSignatureTypes expectedSignatureType = auth.getSignatureFactors();
-        if (!allowedSignatureTypes.contains(expectedSignatureType)) {
+        if (expectedSignatureType == null || !allowedSignatureTypes.contains(expectedSignatureType)) {
             throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_SIGNATURE_TYPE_INVALID");
         }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/SecureVaultService.java
@@ -91,6 +91,10 @@ public class SecureVaultService {
             String applicationId = header.getApplicationKey();
             String signature = header.getSignature();
             PowerAuthPortV2ServiceStub.SignatureType signatureType = converter.convertFrom(header.getSignatureType());
+            if (signatureType == null) {
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+            }
+
             String nonce = header.getNonce();
 
             String reason = null;

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/TokenService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/TokenService.java
@@ -72,8 +72,14 @@ public class TokenService {
             // Prepare a signature type converter
             SignatureTypeConverter converter = new SignatureTypeConverter();
 
+            // Convert signature type
+            PowerAuthPortV2ServiceStub.SignatureType signatureType = converter.convertFrom(signatureFactors);
+            if (signatureType == null) {
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+            }
+
             // Create a token
-            final PowerAuthPortV2ServiceStub.CreateTokenResponse token = powerAuthClient.v2().createToken(activationId, ephemeralPublicKey, converter.convertFrom(signatureFactors));
+            final PowerAuthPortV2ServiceStub.CreateTokenResponse token = powerAuthClient.v2().createToken(activationId, ephemeralPublicKey, signatureType);
 
             // Prepare a response
             final TokenCreateResponse response = new TokenCreateResponse();

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
@@ -78,6 +78,10 @@ public class SecureVaultService {
             String applicationKey = header.getApplicationKey();
             String signature = header.getSignature();
             PowerAuthPortV3ServiceStub.SignatureType signatureType = converter.convertFrom(header.getSignatureType());
+            if (signatureType == null) {
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+            }
+
             String signatureVersion = header.getVersion();
             String nonce = header.getNonce();
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/TokenService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/TokenService.java
@@ -78,6 +78,12 @@ public class TokenService {
             // Prepare a signature type converter
             SignatureTypeConverter converter = new SignatureTypeConverter();
 
+            // Convert signature type
+            PowerAuthPortV3ServiceStub.SignatureType signatureType = converter.convertFrom(signatureFactors);
+            if (signatureType == null) {
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+            }
+
             // Get ECIES headers
             String activationId = authentication.getActivationId();
             PowerAuthSignatureHttpHeader httpHeader = (PowerAuthSignatureHttpHeader) authentication.getHttpHeader();
@@ -85,7 +91,7 @@ public class TokenService {
 
             // Create a token
             final PowerAuthPortV3ServiceStub.CreateTokenResponse token = powerAuthClient.createToken(activationId, applicationKey, ephemeralPublicKey,
-                    encryptedData, mac, nonce, converter.convertFrom(signatureFactors));
+                    encryptedData, mac, nonce, signatureType);
 
             // Prepare a response
             final EciesEncryptedResponse response = new EciesEncryptedResponse();

--- a/powerauth-restful-security-spring-annotation/pom.xml
+++ b/powerauth-restful-security-spring-annotation/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-restful-security-spring-annotation</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <name>powerauth-restful-security-spring-annotation</name>
     <description>PowerAuth RESTful API Security Annotations for Spring</description>
 
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-restful-integration-parent</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -53,12 +53,12 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-base</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-client-spring</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
@@ -221,7 +221,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
 
         // Check if the signature type is allowed
         PowerAuthSignatureTypes expectedSignatureType = PowerAuthSignatureTypes.getEnumFromString(header.getSignatureType());
-        if (!allowedSignatureTypes.contains(expectedSignatureType)) {
+        if (expectedSignatureType == null || !allowedSignatureTypes.contains(expectedSignatureType)) {
             throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
         }
 
@@ -287,7 +287,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
 
         // Check if the signature type is allowed
         PowerAuthSignatureTypes expectedSignatureType = auth.getSignatureFactors();
-        if (!allowedSignatureTypes.contains(expectedSignatureType)) {
+        if (expectedSignatureType == null || !allowedSignatureTypes.contains(expectedSignatureType)) {
             throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_SIGNATURE_TYPE_INVALID");
         }
 

--- a/powerauth-restful-security-spring/pom.xml
+++ b/powerauth-restful-security-spring/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-restful-security-spring</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <name>powerauth-restful-security-spring</name>
     <description>PowerAuth RESTful API Security Additions for Spring</description>
 
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-restful-integration-parent</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-spring-annotation</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/powerauth-restful-server-javaee/pom.xml
+++ b/powerauth-restful-server-javaee/pom.xml
@@ -27,12 +27,12 @@
     <artifactId>powerauth-restful-server-javaee</artifactId>
     <name>powerauth-restful-server-javaee</name>
     <packaging>war</packaging>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.24.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-javaee</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/powerauth-restful-server-spring/pom.xml
+++ b/powerauth-restful-server-spring/pom.xml
@@ -26,7 +26,7 @@
     <name>powerauth-restful-server-spring</name>
     <description>PowerAuth Standard RESTful API</description>
     <artifactId>powerauth-restful-server-spring</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-spring</artifactId>
-            <version>0.24.0</version>
+            <version>0.25.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Other Dependencies -->


### PR DESCRIPTION
This pull request adds proper validation of signature types. Instead of a silent fallback for unknown signature types to `POSSESSION_KNOWLEDGE_BIOMETRY` (in powerauth-restful-integration) or `POSSESSION_KNOWLEDGE` (in powerauth-crypto, see https://github.com/wultra/powerauth-crypto/pull/341/files), the unknown signature type is converted to `null` value. 

The signature type is now validated, so that if the provided signature type has a typo or is unrecognized, the signature type conversion does not work by coincidence.