### PR TITLE
Fix #234: Specifying of flags using activation provider

### DIFF
--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/CustomActivationProvider.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/CustomActivationProvider.java
@@ -22,6 +22,8 @@ package io.getlime.security.powerauth.rest.api.base.provider;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -79,7 +81,7 @@ public interface CustomActivationProvider {
      */
     default boolean shouldAutoCommitActivation(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String activationId, String userId, ActivationType activationType) throws PowerAuthActivationException {
         return false;
-    };
+    }
 
     /**
      * Method is called when activation commit succeeds.
@@ -139,7 +141,7 @@ public interface CustomActivationProvider {
      */
     default Integer getMaxFailedAttemptCount(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String userId, ActivationType activationType) throws PowerAuthActivationException {
         return null;
-    };
+    }
 
     /**
      * Get length of the period of activation record validity during activation in milliseconds.
@@ -158,6 +160,18 @@ public interface CustomActivationProvider {
      */
     default Integer getValidityPeriodDuringActivation(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String userId, ActivationType activationType) throws PowerAuthActivationException {
         return null;
-    };
+    }
+
+    /**
+     * Get activation flags which should be saved for the created activation.
+     * @param identityAttributes Identity related attributes.
+     * @param customAttributes Custom attributes, not related to identity.
+     * @param userId User ID of user who created the activation.
+     * @param activationType Activation type.
+     * @return List of activation flags.
+     */
+    default List<String> getActivationFlags(Map<String, String> identityAttributes, Map<String, Object> customAttributes, String activationId, String userId, ActivationType activationType) {
+        return Collections.emptyList();
+    }
 
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
@@ -106,9 +106,13 @@ public class ActivationService {
                     PowerAuthPortV3ServiceStub.PrepareActivationResponse response = powerAuthClient.prepareActivation(activationCode, applicationKey, ephemeralPublicKey, encryptedData, mac, nonce);
 
                     Map<String, Object> processedCustomAttributes = customAttributes;
-                    // In case a custom activation provider is enabled, process custom attributes
+                    // In case a custom activation provider is enabled, process custom attributes and save any flags
                     if (activationProvider != null) {
                         processedCustomAttributes = activationProvider.processCustomActivationAttributes(customAttributes, response.getActivationId(), response.getUserId(), ActivationType.CODE);
+                        List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), response.getUserId(), ActivationType.CODE);
+                        if (activationFlags != null && !activationFlags.isEmpty()) {
+                            powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                        }
                     }
 
                     boolean notifyActivationCommit = false;
@@ -172,6 +176,12 @@ public class ActivationService {
                     // Process custom attributes using a custom logic
                     final Map<String, Object> processedCustomAttributes = activationProvider.processCustomActivationAttributes(customAttributes, response.getActivationId(), userId, ActivationType.CUSTOM);
 
+                    // Save activation flags in case the provider specified any flags
+                    List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), userId, ActivationType.CUSTOM);
+                    if (activationFlags != null && !activationFlags.isEmpty()) {
+                        powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                    }
+
                     // Check if activation should be committed instantly and if yes, perform commit
                     if (activationProvider.shouldAutoCommitActivation(identity, customAttributes, response.getActivationId(), userId, ActivationType.CUSTOM)) {
                         PowerAuthPortV3ServiceStub.CommitActivationResponse commitResponse = powerAuthClient.commitActivation(response.getActivationId(), null);
@@ -222,9 +232,13 @@ public class ActivationService {
                     PowerAuthPortV3ServiceStub.RecoveryCodeActivationResponse response = powerAuthClient.createActivationUsingRecoveryCode(recoveryCode, recoveryPuk, applicationKey, maxFailedCount, ephemeralPublicKey, encryptedData, mac, nonce);
 
                     Map<String, Object> processedCustomAttributes = customAttributes;
-                    // In case a custom activation provider is enabled, process custom attributes
+                    // In case a custom activation provider is enabled, process custom attributes and save any flags
                     if (activationProvider != null) {
                         processedCustomAttributes = activationProvider.processCustomActivationAttributes(customAttributes, response.getActivationId(), response.getUserId(), ActivationType.RECOVERY);
+                        List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), response.getUserId(), ActivationType.RECOVERY);
+                        if (activationFlags != null && !activationFlags.isEmpty()) {
+                            powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                        }
                     }
 
                     // Automatically commit activation by default, the optional activation provider can override automatic commit


### PR DESCRIPTION
Activation provider can specify flags to be saved for the created activation.