### PR TITLE
Fix #238: Return application roles in authentication

### DIFF
--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/authentication/PowerAuthApiAuthentication.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/authentication/PowerAuthApiAuthentication.java
@@ -22,6 +22,8 @@ package io.getlime.security.powerauth.rest.api.base.authentication;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthHttpHeader;
 
+import java.util.List;
+
 /**
  * Interface for PowerAuth API authentication object used between intermediate server
  * application (such as mobile banking API) and core systems (such as banking core).
@@ -66,6 +68,18 @@ public interface PowerAuthApiAuthentication {
      * @param id Application ID.
      */
     void setApplicationId(Long id);
+
+    /**
+     * Get application roles.
+     * @return Application roles.
+     */
+    List<String> getApplicationRoles();
+
+    /**
+     * Set application roles.
+     * @param applicationRoles Application roles.
+     */
+    void setApplicationRoles(List<String> applicationRoles);
 
     /**
      * Return authentication factors related to the signature that was used to produce

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/authentication/PowerAuthApiAuthenticationImpl.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/authentication/PowerAuthApiAuthenticationImpl.java
@@ -24,6 +24,7 @@ import io.getlime.security.powerauth.http.PowerAuthHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * PowerAuth API authentication object used between intermediate server application (such as mobile 
@@ -39,133 +40,98 @@ public class PowerAuthApiAuthenticationImpl implements PowerAuthApiAuthenticatio
     private String activationId;
     private String userId;
     private Long applicationId;
+    private List<String> applicationRoles;
     private PowerAuthSignatureTypes factors;
     private String version;
     private PowerAuthHttpHeader httpHeader;
 
     /**
-     * Default constructor
+     * Default constructor.
      */
     public PowerAuthApiAuthenticationImpl() {
     }
 
     /**
-     * Constructor for a new PowerAuthApiAuthenticationImpl
-     * @param activationId Activation ID
-     * @param userId User ID
-     * @param applicationId Application ID
-     * @param factors Authentication factors
+     * Constructor for a new PowerAuthApiAuthenticationImpl.
+     * @param activationId Activation ID.
+     * @param userId User ID.
+     * @param applicationId Application ID.
+     * @param applicationRoles Application roles.
+     * @param factors Authentication factors.
      */
-    public PowerAuthApiAuthenticationImpl(String activationId, String userId, Long applicationId, PowerAuthSignatureTypes factors) {
+    public PowerAuthApiAuthenticationImpl(String activationId, String userId, Long applicationId, List<String> applicationRoles, PowerAuthSignatureTypes factors) {
         this.activationId = activationId;
         this.userId = userId;
         this.applicationId = applicationId;
+        this.applicationRoles = applicationRoles;
         this.factors = factors;
     }
 
-    /**
-     * Get user ID
-     * @return User ID
-     */
     @Override
     public String getUserId() {
         return userId;
     }
 
-    /**
-     * Set user ID
-     * @param userId User ID
-     */
     @Override
     public void setUserId(String userId) {
         this.userId = userId;
     }
 
-    /**
-     * Get activation ID
-     * @return Activation ID
-     */
     @Override
     public String getActivationId() {
         return activationId;
     }
 
-    /**
-     * Set activation ID
-     * @param activationId Activation ID
-     */
     @Override
     public void setActivationId(String activationId) {
         this.activationId = activationId;
     }
 
-    /**
-     * Get application ID.
-     * @return Application ID.
-     */
     @Override
     public Long getApplicationId() {
         return applicationId;
     }
 
-    /**
-     * Set application ID.
-     * @param id Application ID.
-     */
     @Override
     public void setApplicationId(Long id) {
         this.applicationId = id;
     }
 
-    /**
-     * Get authentication factors.
-     * @return Authentication factors.
-     */
+    @Override
+    public List<String> getApplicationRoles() {
+        return applicationRoles;
+    }
+
+    @Override
+    public void setApplicationRoles(List<String> applicationRoles) {
+        this.applicationRoles = applicationRoles;
+    }
+
     @Override
     public PowerAuthSignatureTypes getSignatureFactors() {
         return factors;
     }
 
-    /**
-     * Set authentication factors.
-     * @param factors Signature type (signature factors).
-     */
     @Override
     public void setSignatureFactors(PowerAuthSignatureTypes factors) {
         this.factors = factors;
     }
 
-    /**
-     * Get PowerAuth protocol version.
-     * @return PowerAuth protocol version.
-     */
     @Override
     public String getVersion() {
         return version;
     }
 
-    /**
-     * Set PowerAuth protocol version.
-     * @param version PowerAuth protocol version.
-     */
     @Override
     public void setVersion(String version) {
         this.version = version;
     }
 
-    /**
-     * Get parsed PowerAuth HTTP header.
-     * @return PowerAuth HTTP header.
-     */
     @Override
     public PowerAuthHttpHeader getHttpHeader() {
         return httpHeader;
     }
 
-    /**
-     * Set parsed PowerAuth HTTP header.
-     * @param httpHeader PowerAuth HTTP header.
-     */
     @Override
     public void setHttpHeader(PowerAuthHttpHeader httpHeader) {
         this.httpHeader = httpHeader;

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
@@ -111,7 +111,7 @@ public class ActivationService {
                         processedCustomAttributes = activationProvider.processCustomActivationAttributes(customAttributes, response.getActivationId(), response.getUserId(), ActivationType.CODE);
                         List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), response.getUserId(), ActivationType.CODE);
                         if (activationFlags != null && !activationFlags.isEmpty()) {
-                            powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                            powerAuthClient.addActivationFlags(response.getActivationId(), activationFlags);
                         }
                     }
 
@@ -179,7 +179,7 @@ public class ActivationService {
                     // Save activation flags in case the provider specified any flags
                     List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), userId, ActivationType.CUSTOM);
                     if (activationFlags != null && !activationFlags.isEmpty()) {
-                        powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                        powerAuthClient.addActivationFlags(response.getActivationId(), activationFlags);
                     }
 
                     // Check if activation should be committed instantly and if yes, perform commit
@@ -237,7 +237,7 @@ public class ActivationService {
                         processedCustomAttributes = activationProvider.processCustomActivationAttributes(customAttributes, response.getActivationId(), response.getUserId(), ActivationType.RECOVERY);
                         List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), response.getUserId(), ActivationType.RECOVERY);
                         if (activationFlags != null && !activationFlags.isEmpty()) {
-                            powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                            powerAuthClient.addActivationFlags(response.getActivationId(), activationFlags);
                         }
                     }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/authentication/PowerAuthApiAuthenticationImpl.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/authentication/PowerAuthApiAuthenticationImpl.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * PowerAuth API authentication object used between intermediate server application (such as mobile 
@@ -45,6 +46,7 @@ public class PowerAuthApiAuthenticationImpl extends AbstractAuthenticationToken 
     private String activationId;
     private String userId;
     private Long applicationId;
+    private List<String> applicationRoles;
     private PowerAuthSignatureTypes factors;
     private String version;
     private PowerAuthHttpHeader httpHeader;
@@ -57,13 +59,14 @@ public class PowerAuthApiAuthenticationImpl extends AbstractAuthenticationToken 
     }
 
     /**
-     * Constructor for a new PowerAuthApiAuthenticationImpl
-     * @param activationId Activation ID
-     * @param userId User ID
-     * @param applicationId Application ID
-     * @param factors Authentication factors
+     * Constructor for a new PowerAuthApiAuthenticationImpl.
+     * @param activationId Activation ID.
+     * @param userId User ID.
+     * @param applicationId Application ID.
+     * @param applicationRoles Application roles.
+     * @param factors Authentication factors.
      */
-    public PowerAuthApiAuthenticationImpl(String activationId, String userId, Long applicationId, PowerAuthSignatureTypes factors) {
+    public PowerAuthApiAuthenticationImpl(String activationId, String userId, Long applicationId, List<String> applicationRoles, PowerAuthSignatureTypes factors) {
         super(null);
         this.activationId = activationId;
         this.userId = userId;
@@ -93,109 +96,71 @@ public class PowerAuthApiAuthenticationImpl extends AbstractAuthenticationToken 
         return this.activationId;
     }
 
-    /**
-     * Get user ID
-     * @return User ID
-     */
     @Override
     public String getUserId() {
         return userId;
     }
 
-    /**
-     * Set user ID
-     * @param userId User ID
-     */
     @Override
     public void setUserId(String userId) {
         this.userId = userId;
     }
 
-    /**
-     * Get activation ID
-     * @return Activation ID
-     */
     @Override
     public String getActivationId() {
         return activationId;
     }
 
-    /**
-     * Set activation ID
-     * @param activationId Activation ID
-     */
     @Override
     public void setActivationId(String activationId) {
         this.activationId = activationId;
     }
 
-    /**
-     * Get application ID.
-     * @return Application ID.
-     */
     @Override
     public Long getApplicationId() {
         return applicationId;
     }
 
-    /**
-     * Set application ID.
-     * @param id Application ID.
-     */
     @Override
     public void setApplicationId(Long id) {
         this.applicationId = id;
     }
 
-    /**
-     * Get authentication factors.
-     * @return Authentication factors.
-     */
+    @Override
+    public List<String> getApplicationRoles() {
+        return applicationRoles;
+    }
+
+    @Override
+    public void setApplicationRoles(List<String> applicationRoles) {
+        this.applicationRoles = applicationRoles;
+    }
+
     @Override
     public PowerAuthSignatureTypes getSignatureFactors() {
         return factors;
     }
 
-    /**
-     * Set authentication factors.
-     * @param factors Signature type (signature factors).
-     */
     @Override
     public void setSignatureFactors(PowerAuthSignatureTypes factors) {
         this.factors = factors;
     }
 
-    /**
-     * Get PowerAuth protocol version.
-     * @return PowerAuth protocol version.
-     */
     @Override
     public String getVersion() {
         return version;
     }
 
-    /**
-     * Set PowerAuth protocol version.
-     * @param version PowerAuth protocol version.
-     */
     @Override
     public void setVersion(String version) {
         this.version = version;
     }
 
-    /**
-     * Get parsed PowerAuth HTTP header.
-     * @return PowerAuth HTTP header.
-     */
     @Override
     public PowerAuthHttpHeader getHttpHeader() {
         return httpHeader;
     }
 
-    /**
-     * Set parsed PowerAuth HTTP header.
-     * @param httpHeader PowerAuth HTTP header.
-     */
     @Override
     public void setHttpHeader(PowerAuthHttpHeader httpHeader) {
         this.httpHeader = httpHeader;

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
@@ -122,7 +122,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
 
             if (soapResponse.isSignatureValid()) {
                 return copyAuthenticationAttributes(soapResponse.getActivationId(), soapResponse.getUserId(),
-                        soapResponse.getApplicationId(), PowerAuthSignatureTypes.getEnumFromString(soapResponse.getSignatureType().value()),
+                        soapResponse.getApplicationId(), soapResponse.getApplicationRoles(), PowerAuthSignatureTypes.getEnumFromString(soapResponse.getSignatureType().value()),
                         authentication.getVersion(), authentication.getHttpHeader());
             } else {
                 return null;
@@ -151,7 +151,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             final ValidateTokenResponse soapResponse = powerAuthClient.validateToken(soapRequest);
             if (soapResponse.isTokenValid()) {
                 return copyAuthenticationAttributes(soapResponse.getActivationId(), soapResponse.getUserId(),
-                        soapResponse.getApplicationId(), PowerAuthSignatureTypes.getEnumFromString(soapResponse.getSignatureType().value()),
+                        soapResponse.getApplicationId(), soapResponse.getApplicationRoles(), PowerAuthSignatureTypes.getEnumFromString(soapResponse.getSignatureType().value()),
                         authentication.getVersion(), authentication.getHttpHeader());
             } else {
                 return null;
@@ -167,14 +167,19 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
      * @param activationId Activation ID.
      * @param userId User ID.
      * @param applicationId Application ID.
+     * @param applicationRoles Application roles.
      * @param signatureType Signature Type.
+     * @param version PowerAuth protocol version.
+     * @param httpHeader Raw PowerAuth http header.
      * @return Initialized instance of API authentication.
      */
-    private PowerAuthApiAuthenticationImpl copyAuthenticationAttributes(String activationId, String userId, Long applicationId, PowerAuthSignatureTypes signatureType, String version, PowerAuthHttpHeader httpHeader) {
+    private PowerAuthApiAuthenticationImpl copyAuthenticationAttributes(String activationId, String userId, Long applicationId, List<String> applicationRoles,
+                                                                        PowerAuthSignatureTypes signatureType, String version, PowerAuthHttpHeader httpHeader) {
         PowerAuthApiAuthenticationImpl apiAuthentication = new PowerAuthApiAuthenticationImpl();
         apiAuthentication.setActivationId(activationId);
         apiAuthentication.setUserId(userId);
         apiAuthentication.setApplicationId(applicationId);
+        apiAuthentication.setApplicationRoles(applicationRoles);
         apiAuthentication.setSignatureFactors(signatureType);
         apiAuthentication.setAuthenticated(true);
         apiAuthentication.setVersion(version);

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
@@ -125,7 +125,7 @@ public class ActivationService {
                         processedCustomAttributes = activationProvider.processCustomActivationAttributes(customAttributes, response.getActivationId(), response.getUserId(), ActivationType.CODE);
                         List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), response.getUserId(), ActivationType.CODE);
                         if (activationFlags != null && !activationFlags.isEmpty()) {
-                            powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                            powerAuthClient.addActivationFlags(response.getActivationId(), activationFlags);
                         }
                     }
 
@@ -193,7 +193,7 @@ public class ActivationService {
                     // Save activation flags in case the provider specified any flags
                     List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), userId, ActivationType.CUSTOM);
                     if (activationFlags != null && !activationFlags.isEmpty()) {
-                        powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                        powerAuthClient.addActivationFlags(response.getActivationId(), activationFlags);
                     }
 
                     // Check if activation should be committed instantly and if yes, perform commit
@@ -251,7 +251,7 @@ public class ActivationService {
                         processedCustomAttributes = activationProvider.processCustomActivationAttributes(customAttributes, response.getActivationId(), response.getUserId(), ActivationType.RECOVERY);
                         List<String> activationFlags = activationProvider.getActivationFlags(identity, processedCustomAttributes, response.getActivationId(), response.getUserId(), ActivationType.RECOVERY);
                         if (activationFlags != null && !activationFlags.isEmpty()) {
-                            powerAuthClient.createActivationFlags(response.getActivationId(), activationFlags);
+                            powerAuthClient.addActivationFlags(response.getActivationId(), activationFlags);
                         }
                     }
 


### PR DESCRIPTION
Application roles are now available in `PowerAuthApiAuthentication`. There are additional minor changes related to:
https://github.com/wultra/powerauth-server/pull/444