### PR TITLE
Fix #210: Review logging in restful-integration

### DIFF
--- a/docs/RESTful-API-for-JavaEE.md
+++ b/docs/RESTful-API-for-JavaEE.md
@@ -426,7 +426,7 @@ public class EncryptedController {
             // Return response
             return encryptedResponse;
 
-        } catch (IOException e) {
+        } catch (IOException ex) {
             throw new PowerAuthActivationException();
         }
 

--- a/docs/RESTful-API-for-JavaEE.md
+++ b/docs/RESTful-API-for-JavaEE.md
@@ -195,12 +195,10 @@ public class AuthenticationController {
                 authHeader
         );
 
-        if (auth != null && auth.getUserId() != null) {
-            return new PowerAuthApiResponse<>("OK", "Hooray! User: " + auth.getUserId());
-        } else {
+        if (auth == null || auth.getUserId() == null) {
             return new PowerAuthApiResponse<>("ERROR", "Authentication failed.");
         }
-
+        return new PowerAuthApiResponse<>("OK", "Hooray! User: " + auth.getUserId());
     }
 }
 ```
@@ -229,7 +227,7 @@ public class AuthenticationController {
     public PowerAuthApiResponse<String> getBalance(@HeaderParam(value = PowerAuthTokenHttpHeader.HEADER_NAME) String tokenHeader) throws PowerAuthAuthenticationException {
         PowerAuthApiAuthentication auth = authenticationProvider.validateToken(tokenHeader);
         if (apiAuthentication == null) {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_INVALID");
+            throw new PowerAuthTokenInvalidException();
         } else {
             String userId = apiAuthentication.getUserId();
             String balance = service.getBalanceForUser(userId);
@@ -270,7 +268,7 @@ public class EncryptedDataExchangeController {
         EciesEncryptionContext eciesContext = eciesEncryption.getContext();
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Prepare response object
@@ -308,7 +306,7 @@ public class EncryptedDataExchangeController {
         EciesEncryptionContext eciesContext = eciesEncryption.getContext();
     
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
     
         // Prepare response object
@@ -348,7 +346,7 @@ public class EncryptedDataExchangeController {
         DataExchangeRequest request = eciesEncryption.getRequestObject();
     
         if (eciesEncryption.getContext() == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
     
         // Verify PowerAuth signature
@@ -358,15 +356,14 @@ public class EncryptedDataExchangeController {
                     authHeader
         );
                 
-        if (auth != null && auth.getUserId() != null) {
-            // Prepare response object
-            DataExchangeResponse exchangeResponse = new DataExchangeResponse("Server successfully decrypted data and verified signature, request data: " + (request == null ? "''" : request.getData()) + ", user ID: " + auth.getUserId());
-    
-            // Encrypt response
-            return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getUserId() == null) {
+            throw new PowerAuthSignatureInvalidException();
         }
+        // Prepare response object
+        DataExchangeResponse exchangeResponse = new DataExchangeResponse("Server successfully decrypted data and verified signature, request data: " + (request == null ? "''" : request.getData()) + ", user ID: " + auth.getUserId());
+    
+        // Encrypt response
+        return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
     }
 }
 ```
@@ -398,14 +395,14 @@ public class EncryptedController {
             // Prepare an encryptor
             final PowerAuthNonPersonalizedEncryptor encryptor = encryptorFactory.buildNonPersonalizedEncryptor(encryptedRequest);
             if (encryptor == null) {
-                throw new EncryptionException("Unable to initialize encryptor.");
+                throw new PowerAuthEncryptionException();
             }
 
             // Decrypt the request object
             OriginalRequest request = encryptor.decrypt(object, OriginalRequest.class);
 
             if (request == null) {
-                throw new EncryptionException("Unable to decrypt request object.");
+                throw new PowerAuthEncryptionException();
             }
 
             // ... do your business logic with OriginalRequest instance
@@ -420,14 +417,14 @@ public class EncryptedController {
             final PowerAuthApiResponse<NonPersonalizedEncryptedPayloadModel> encryptedResponse = encryptor.encrypt(response);
 
             if (encryptedResponse == null) {
-                throw new EncryptionException("Unable to encrypt response object.");
+                throw new PowerAuthEncryptionException();
             }
 
             // Return response
             return encryptedResponse;
 
         } catch (IOException ex) {
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
 
     }

--- a/docs/RESTful-API-for-JavaEE.md
+++ b/docs/RESTful-API-for-JavaEE.md
@@ -229,7 +229,7 @@ public class AuthenticationController {
     public PowerAuthApiResponse<String> getBalance(@HeaderParam(value = PowerAuthTokenHttpHeader.HEADER_NAME) String tokenHeader) throws PowerAuthAuthenticationException {
         PowerAuthApiAuthentication auth = authenticationProvider.validateToken(tokenHeader);
         if (apiAuthentication == null) {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_INVALID");
         } else {
             String userId = apiAuthentication.getUserId();
             String balance = service.getBalanceForUser(userId);
@@ -365,7 +365,7 @@ public class EncryptedDataExchangeController {
             // Encrypt response
             return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 }

--- a/docs/RESTful-API-for-JavaEE.md
+++ b/docs/RESTful-API-for-JavaEE.md
@@ -365,7 +365,7 @@ public class EncryptedDataExchangeController {
             // Encrypt response
             return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed.");
+            throw new PowerAuthAuthenticationException();
         }
     }
 }

--- a/docs/RESTful-API-for-Spring.md
+++ b/docs/RESTful-API-for-Spring.md
@@ -454,7 +454,7 @@ public class EncryptedController {
             // Return response
             return encryptedResponse;
 
-        } catch (IOException e) {
+        } catch (IOException ex) {
             throw new PowerAuthActivationException();
         }
 

--- a/docs/RESTful-API-for-Spring.md
+++ b/docs/RESTful-API-for-Spring.md
@@ -233,7 +233,7 @@ public class AuthenticationController {
             return new MyApiResponse(Status.OK, userId);
         } else {
             // handle authentication failure
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 
@@ -266,7 +266,7 @@ public class AuthenticationController {
             SecurityContextHolder.getContext().setAuthentication((Authentication) apiAuthentication);
             return new PowerAuthAPIResponse<String>("OK", "User " + userId);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
     }
@@ -292,7 +292,7 @@ public class AuthenticationController {
     @PowerAuthToken
     public @ResponseBody PowerAuthAPIResponse<String> getBalance(PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException {
         if (apiAuthentication == null) {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_INVALID");
         } else {
             String userId = apiAuthentication.getUserId();
             String balance = service.getBalanceForUser(userId);
@@ -382,7 +382,7 @@ public class EncryptedDataExchangeController {
                                                                 PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
         if (auth == null || auth.getUserId() == null) {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         if (eciesContext == null) {

--- a/docs/RESTful-API-for-Spring.md
+++ b/docs/RESTful-API-for-Spring.md
@@ -266,7 +266,7 @@ public class AuthenticationController {
             SecurityContextHolder.getContext().setAuthentication((Authentication) apiAuthentication);
             return new PowerAuthAPIResponse<String>("OK", "User " + userId);
         } else {
-            throw new PowerAuthAuthenticationException("USER_NOT_AUTHENTICATED");
+            throw new PowerAuthAuthenticationException();
         }
 
     }
@@ -382,11 +382,11 @@ public class EncryptedDataExchangeController {
                                                                 PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
         if (auth == null || auth.getUserId() == null) {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException();
         }
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Return a slightly different String containing original data in response

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthAuthenticationException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthAuthenticationException.java
@@ -48,6 +48,14 @@ public class PowerAuthAuthenticationException extends Exception {
     }
 
     /**
+     * Constructor with a cause.
+     * @param cause Error cause.
+     */
+    public PowerAuthAuthenticationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
      * Get the default error code, used for example in REST response.
      * @return Default error code.
      */

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthEncryptionException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthEncryptionException.java
@@ -48,6 +48,14 @@ public class PowerAuthEncryptionException extends Exception {
     }
 
     /**
+     * Constructor with a cause.
+     * @param cause Error cause.
+     */
+    public PowerAuthEncryptionException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
      * Get the default error code, used for example in REST response.
      * @return Default error code.
      */

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthRecoveryException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthRecoveryException.java
@@ -20,7 +20,7 @@
 package io.getlime.security.powerauth.rest.api.base.exception;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception thrown in case PowerAuth recovery fails, with optional current PUK index.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthSecureVaultException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthSecureVaultException.java
@@ -47,6 +47,14 @@ public class PowerAuthSecureVaultException extends Exception {
     }
 
     /**
+     * Constructor with a cause.
+     * @param cause Error cause.
+     */
+    public PowerAuthSecureVaultException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
      * Get the default error code, used for example in REST response.
      * @return Default error code.
      */

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthUpgradeException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/PowerAuthUpgradeException.java
@@ -48,6 +48,14 @@ public class PowerAuthUpgradeException extends Exception {
     }
 
     /**
+     * Constructor with a cause.
+     * @param cause Error cause.
+     */
+    public PowerAuthUpgradeException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
      * Get the default error code, used for example in REST response.
      * @return Default error code.
      */

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthHeaderMissingException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthHeaderMissingException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth HTTP header is missing.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthHeaderMissingException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = -2359879611684674690L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_HTTP_HEADER_MISSING";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthHeaderMissingException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthHeaderMissingException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthHeaderMissingException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthInvalidRequestException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthInvalidRequestException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth authentication request is invalid.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthInvalidRequestException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = -6068516562428771519L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_REQUEST_INVALID";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthInvalidRequestException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthInvalidRequestException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthInvalidRequestException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthRecoveryConfirmationException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthRecoveryConfirmationException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth recovery confirmation fails with an error.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthRecoveryConfirmationException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = 7840709829931142914L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_RECOVERY_CONFIRM_ERROR";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthRecoveryConfirmationException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthRecoveryConfirmationException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthRecoveryConfirmationException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthRequestFilterException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthRequestFilterException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth authentication request filter is missing.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthRequestFilterException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = -6832983011115467428L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_REQUEST_FILTER_MISSING";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthRequestFilterException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthRequestFilterException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthRequestFilterException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthSignatureErrorException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthSignatureErrorException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth signature validation fails with an error.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthSignatureErrorException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = 1428981649658439163L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_SIGNATURE_ERROR";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthSignatureErrorException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthSignatureErrorException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthSignatureErrorException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthSignatureInvalidException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthSignatureInvalidException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth signature validation fails.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthSignatureInvalidException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = -8628851623611808408L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_SIGNATURE_INVALID";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthSignatureInvalidException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthSignatureInvalidException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthSignatureInvalidException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthSignatureTypeInvalidException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthSignatureTypeInvalidException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth signature type is invalid.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthSignatureTypeInvalidException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = 6914310542180702420L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_SIGNATURE_TYPE_INVALID";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthSignatureTypeInvalidException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthSignatureTypeInvalidException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthSignatureTypeInvalidException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthTokenErrorException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthTokenErrorException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth token validation fails with an error.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthTokenErrorException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = 3900547437080764802L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_TOKEN_ERROR";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthTokenErrorException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthTokenErrorException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthTokenErrorException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthTokenInvalidException.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/exception/authentication/PowerAuthTokenInvalidException.java
@@ -2,7 +2,7 @@
  * PowerAuth integration libraries for RESTful API applications, examples and
  * related software components
  *
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -17,32 +17,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.getlime.security.powerauth.rest.api.base.exception;
+package io.getlime.security.powerauth.rest.api.base.exception.authentication;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 
 /**
- * Exception related to processes during a new activation process.
+ * Exception raised in case PowerAuth token validation fails.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
  */
-public class PowerAuthActivationException extends Exception {
+public class PowerAuthTokenInvalidException extends PowerAuthAuthenticationException {
 
-    private static final long serialVersionUID = -7975115359211508795L;
+    private static final long serialVersionUID = 1052831183125328518L;
 
-    private static final String DEFAULT_CODE = "ERR_ACTIVATION";
-    private static final String DEFAULT_ERROR = "POWER_AUTH_ACTIVATION_INVALID";
+    private static final String DEFAULT_CODE = "ERR_AUTHENTICATION";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_TOKEN_INVALID";
 
     /**
-     * Default constructor.
+     * Default constructor
      */
-    public PowerAuthActivationException() {
+    public PowerAuthTokenInvalidException() {
         super(DEFAULT_ERROR);
     }
 
     /**
-     * Constructor with a custom error message.
-     * @param message Error message.
+     * Constructor with a custom error message
+     * @param message Error message
      */
-    public PowerAuthActivationException(String message) {
+    public PowerAuthTokenInvalidException(String message) {
         super(message);
     }
 
@@ -50,12 +53,12 @@ public class PowerAuthActivationException extends Exception {
      * Constructor with a cause.
      * @param cause Error cause.
      */
-    public PowerAuthActivationException(Throwable cause) {
+    public PowerAuthTokenInvalidException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Get default error code, used for example in the REST response.
+     * Get the default error code, used for example in REST response.
      * @return Default error code.
      */
     public String getDefaultCode() {

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthAuthenticationProviderBase.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthAuthenticationProviderBase.java
@@ -23,8 +23,11 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncryption;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthRequestFilterException;
 import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestObjects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -38,6 +41,8 @@ import java.util.List;
  *
  */
 public abstract class PowerAuthAuthenticationProviderBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(PowerAuthAuthenticationProviderBase.class);
 
     /**
      * Validate the signature from the PowerAuth HTTP header against the provided HTTP method, request body and URI identifier.
@@ -157,7 +162,8 @@ public abstract class PowerAuthAuthenticationProviderBase {
             // Request data was not encrypted - use regular PowerAuth request body for signature validation
             PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) servletRequest.getAttribute(PowerAuthRequestObjects.REQUEST_BODY));
             if (requestBody == null) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_FILTER_MISSING");
+                logger.warn("The X-PowerAuth-Request-Body request attribute is missing. Register the PowerAuthRequestFilter to fix this error.");
+                throw new PowerAuthRequestFilterException();
             }
             return requestBody.getRequestBytes();
         }

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthAuthenticationProviderBase.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthAuthenticationProviderBase.java
@@ -157,7 +157,7 @@ public abstract class PowerAuthAuthenticationProviderBase {
             // Request data was not encrypted - use regular PowerAuth request body for signature validation
             PowerAuthRequestBody requestBody = ((PowerAuthRequestBody) servletRequest.getAttribute(PowerAuthRequestObjects.REQUEST_BODY));
             if (requestBody == null) {
-                throw new PowerAuthAuthenticationException("The X-PowerAuth-Request-Body request attribute is missing, register the PowerAuthRequestFilter to fix this error");
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_FILTER_MISSING");
             }
             return requestBody.getRequestBytes();
         }

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthEncryptionProviderBase.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthEncryptionProviderBase.java
@@ -260,7 +260,7 @@ public abstract class PowerAuthEncryptionProviderBase {
             try {
                 PowerAuthSignatureHttpHeaderValidator.validate(header);
             } catch (InvalidPowerAuthHttpHeaderException ex) {
-                logger.warn("PowerAuth signature HTTP header is invalid, error: {}", ex.getMessage());
+                logger.warn("Signature validation failed, error: {}", ex.getMessage());
                 throw new PowerAuthEncryptionException();
             }
 
@@ -277,7 +277,7 @@ public abstract class PowerAuthEncryptionProviderBase {
             try {
                 PowerAuthEncryptionHttpHeaderValidator.validate(header);
             } catch (InvalidPowerAuthHttpHeaderException ex) {
-                logger.warn("PowerAuth encryption HTTP header is invalid, error: {}", ex.getMessage());
+                logger.warn("Encryption validation failed, error: {}", ex.getMessage());
                 throw new PowerAuthEncryptionException();
             }
 

--- a/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthEncryptionProviderBase.java
+++ b/powerauth-restful-security-base/src/main/java/io/getlime/security/powerauth/rest/api/base/provider/PowerAuthEncryptionProviderBase.java
@@ -171,8 +171,8 @@ public abstract class PowerAuthEncryptionProviderBase {
             // Set encryption object in HTTP servlet request
             request.setAttribute(PowerAuthRequestObjects.ENCRYPTION_OBJECT, eciesEncryption);
         } catch (Exception ex) {
-            logger.debug("Request decryption failed, error: " + ex.getMessage(), ex);
-            throw new PowerAuthEncryptionException("Invalid request");
+            logger.debug("Request decryption failed, error: {}", ex.getMessage());
+            throw new PowerAuthEncryptionException();
         }
         return eciesEncryption;
     }
@@ -193,7 +193,7 @@ public abstract class PowerAuthEncryptionProviderBase {
             String macBase64 = BaseEncoding.base64().encode(cryptogram.getMac());
             return new EciesEncryptedResponse(encryptedDataBase64, macBase64);
         } catch (Exception ex) {
-            logger.debug("Request encryption failed, error: " + ex.getMessage(), ex);
+            logger.debug("Response encryption failed, error: {}", ex.getMessage());
             return null;
         }
     }
@@ -259,8 +259,9 @@ public abstract class PowerAuthEncryptionProviderBase {
             // Validate the signature HTTP header
             try {
                 PowerAuthSignatureHttpHeaderValidator.validate(header);
-            } catch (InvalidPowerAuthHttpHeaderException e) {
-                throw new PowerAuthEncryptionException(e.getMessage());
+            } catch (InvalidPowerAuthHttpHeaderException ex) {
+                logger.warn("PowerAuth signature HTTP header is invalid, error: {}", ex.getMessage());
+                throw new PowerAuthEncryptionException();
             }
 
             // Construct encryption parameters object
@@ -275,8 +276,9 @@ public abstract class PowerAuthEncryptionProviderBase {
             // Validate the encryption HTTP header
             try {
                 PowerAuthEncryptionHttpHeaderValidator.validate(header);
-            } catch (InvalidPowerAuthHttpHeaderException e) {
-                throw new PowerAuthEncryptionException(e.getMessage());
+            } catch (InvalidPowerAuthHttpHeaderException ex) {
+                logger.warn("PowerAuth encryption HTTP header is invalid, error: {}", ex.getMessage());
+                throw new PowerAuthEncryptionException();
             }
 
             // Construct encryption parameters object

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/ActivationController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/ActivationController.java
@@ -115,7 +115,7 @@ public class ActivationController {
         }
         if (!"2.0".equals(apiAuthentication.getVersion()) && !"2.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         return new ObjectResponse<>(activationServiceV3.removeActivation(apiAuthentication));
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/ActivationController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/ActivationController.java
@@ -111,7 +111,7 @@ public class ActivationController {
         // Request body needs to be set to null because the SDK uses null for the signature, although {} is sent as request body
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", null, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
         if (!"2.0".equals(apiAuthentication.getVersion()) && !"2.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/ActivationController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/ActivationController.java
@@ -25,6 +25,8 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.model.request.v2.ActivationCreateRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
@@ -75,7 +77,8 @@ public class ActivationController {
             logger.warn("Invalid request object in activation create");
             throw new PowerAuthActivationException();
         }
-        return new ObjectResponse<>(activationServiceV2.createActivation(request.getRequestObject()));
+        ActivationCreateResponse response = activationServiceV2.createActivation(request.getRequestObject());
+        return new ObjectResponse<>(response);
     }
 
     /**
@@ -93,7 +96,8 @@ public class ActivationController {
             logger.warn("Invalid request object in activation status");
             throw new PowerAuthActivationException();
         }
-        return new ObjectResponse<>(activationServiceV3.getActivationStatus(request.getRequestObject()));
+        ActivationStatusResponse response = activationServiceV3.getActivationStatus(request.getRequestObject());
+        return new ObjectResponse<>(response);
     }
 
     /**
@@ -111,13 +115,15 @@ public class ActivationController {
         // Request body needs to be set to null because the SDK uses null for the signature, although {} is sent as request body
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", null, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
         if (!"2.0".equals(apiAuthentication.getVersion()) && !"2.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-        return new ObjectResponse<>(activationServiceV3.removeActivation(apiAuthentication));
+        ActivationRemoveResponse response = activationServiceV3.removeActivation(apiAuthentication);
+        return new ObjectResponse<>(response);
     }
 
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
@@ -78,7 +78,7 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("PowerAuth signature HTTP header is invalid, error: {}", ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
             throw new PowerAuthAuthenticationException();
         }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
@@ -79,12 +79,12 @@ public class SecureVaultController {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         if (!"2.0".equals(header.getVersion()) && !"2.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
 
         return new ObjectResponse<>(secureVaultServiceV2.vaultUnlock(signatureHeader, request.getRequestObject(), httpServletRequest));

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
@@ -78,7 +78,8 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("PowerAuth signature HTTP header is invalid, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
 
         if (!"2.0".equals(header.getVersion()) && !"2.1".equals(header.getVersion())) {

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SecureVaultController.java
@@ -26,6 +26,8 @@ import io.getlime.security.powerauth.http.validator.InvalidPowerAuthHttpHeaderEx
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.service.v2.SecureVaultService;
 import io.getlime.security.powerauth.rest.api.model.request.v2.VaultUnlockRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.VaultUnlockResponse;
@@ -78,16 +80,16 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.warn("Signature HTTP header validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthSignatureInvalidException(ex);
         }
 
         if (!"2.0".equals(header.getVersion()) && !"2.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-
-        return new ObjectResponse<>(secureVaultServiceV2.vaultUnlock(signatureHeader, request.getRequestObject(), httpServletRequest));
+        VaultUnlockResponse response = secureVaultServiceV2.vaultUnlock(signatureHeader, request.getRequestObject(), httpServletRequest);
+        return new ObjectResponse<>(response);
     }
 
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SignatureController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SignatureController.java
@@ -127,11 +127,12 @@ public class SignatureController {
                 }
                 return new Response();
             }
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException();
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SignatureController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SignatureController.java
@@ -123,16 +123,16 @@ public class SignatureController {
             if (authentication != null && authentication.getActivationId() != null) {
                 if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
                     logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                    throw new PowerAuthAuthenticationException();
+                    throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
                 }
                 return new Response();
             }
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_ERROR");
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SignatureController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/SignatureController.java
@@ -24,6 +24,9 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureErrorException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,19 +123,20 @@ public class SignatureController {
                             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
                     )
             );
-            if (authentication != null && authentication.getActivationId() != null) {
-                if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
-                    logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                    throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-                }
-                return new Response();
+            if (authentication == null || authentication.getActivationId() == null) {
+                logger.debug("Signature validation failed");
+                throw new PowerAuthSignatureInvalidException();
             }
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
+                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+                throw new PowerAuthInvalidRequestException();
+            }
+            return new Response();
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_ERROR");
+            throw new PowerAuthSignatureErrorException(ex);
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/TokenController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/TokenController.java
@@ -77,7 +77,7 @@ public class TokenController {
 
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         // Verify request signature before creating token
         PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature(
@@ -91,11 +91,11 @@ public class TokenController {
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new ObjectResponse<>(tokenServiceV2.createToken(request.getRequestObject(), authentication));
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 
@@ -108,7 +108,7 @@ public class TokenController {
                                                            @HeaderParam(PowerAuthSignatureHttpHeader.HEADER_NAME) String authHeader) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         // Verify request signature before removing token
         PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature(
@@ -122,11 +122,11 @@ public class TokenController {
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/TokenController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v2/TokenController.java
@@ -26,6 +26,8 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.http.PowerAuthTokenHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveRequest;
@@ -77,7 +79,7 @@ public class TokenController {
 
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
         // Verify request signature before creating token
         PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature(
@@ -88,15 +90,16 @@ public class TokenController {
                         PowerAuthSignatureTypes.POSSESSION_BIOMETRY,
                         PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
                 ));
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return new ObjectResponse<>(tokenServiceV2.createToken(request.getRequestObject(), authentication));
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        TokenCreateResponse response = tokenServiceV2.createToken(request.getRequestObject(), authentication);
+        return new ObjectResponse<>(response);
     }
 
     @POST
@@ -108,7 +111,7 @@ public class TokenController {
                                                            @HeaderParam(PowerAuthSignatureHttpHeader.HEADER_NAME) String authHeader) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
         // Verify request signature before removing token
         PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature(
@@ -119,15 +122,16 @@ public class TokenController {
                         PowerAuthSignatureTypes.POSSESSION_BIOMETRY,
                         PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
                 ));
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        TokenRemoveResponse response = tokenServiceV3.removeToken(request.getRequestObject(), authentication);
+        return new ObjectResponse<>(response);
     }
 
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
@@ -29,6 +29,8 @@ import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivation
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthEncryptionException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthRecoveryException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthEncryptionProvider;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
@@ -83,7 +85,7 @@ public class ActivationController {
             return encryptionProvider.encryptResponse(layer1Response, eciesEncryption);
         } catch (PowerAuthEncryptionException ex) {
             logger.warn("Encryption failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
     }
 
@@ -102,7 +104,8 @@ public class ActivationController {
             logger.warn("Invalid request object in activation status");
             throw new PowerAuthActivationException();
         }
-        return new ObjectResponse<>(activationServiceV3.getActivationStatus(request.getRequestObject()));
+        ActivationStatusResponse response = activationServiceV3.getActivationStatus(request.getRequestObject());
+        return new ObjectResponse<>(response);
     }
 
     /**
@@ -120,13 +123,15 @@ public class ActivationController {
         byte[] requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
         if (!"3.0".equals(apiAuthentication.getVersion()) && !"3.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-        return new ObjectResponse<>(activationServiceV3.removeActivation(apiAuthentication));
+        ActivationRemoveResponse response = activationServiceV3.removeActivation(apiAuthentication);
+        return new ObjectResponse<>(response);
     }
 
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
@@ -120,7 +120,7 @@ public class ActivationController {
         byte[] requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
         if (!"3.0".equals(apiAuthentication.getVersion()) && !"3.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
@@ -82,6 +82,7 @@ public class ActivationController {
             ActivationLayer1Response layer1Response = activationServiceV3.createActivation(layer1Request, eciesEncryption);
             return encryptionProvider.encryptResponse(layer1Response, eciesEncryption);
         } catch (PowerAuthEncryptionException ex) {
+            logger.warn("Encryption failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }
@@ -119,7 +120,7 @@ public class ActivationController {
         byte[] requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException();
         }
         if (!"3.0".equals(apiAuthentication.getVersion()) && !"3.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/ActivationController.java
@@ -120,11 +120,11 @@ public class ActivationController {
         byte[] requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         if (!"3.0".equals(apiAuthentication.getVersion()) && !"3.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         return new ObjectResponse<>(activationServiceV3.removeActivation(apiAuthentication));
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/RecoveryController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/RecoveryController.java
@@ -80,7 +80,7 @@ public class RecoveryController {
 
         if (request == null) {
             logger.warn("Invalid request object in confirm recovery");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         // Verify request signature before creating token
         PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature(
@@ -91,15 +91,15 @@ public class RecoveryController {
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
                 logger.warn("Missing nonce in ECIES request data");
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return recoveryService.confirmRecoveryCode(request, authentication);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/RecoveryController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/RecoveryController.java
@@ -23,6 +23,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.jaxrs.service.v3.RecoveryService;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -80,7 +82,7 @@ public class RecoveryController {
 
         if (request == null) {
             logger.warn("Invalid request object in confirm recovery");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
         // Verify request signature before creating token
         PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature(
@@ -88,19 +90,19 @@ public class RecoveryController {
                 Collections.singletonList(
                         PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE
                 ));
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
-                logger.warn("Missing nonce in ECIES request data");
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return recoveryService.confirmRecoveryCode(request, authentication);
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
+            logger.warn("Missing nonce in ECIES request data");
+            throw new PowerAuthInvalidRequestException();
+        }
+        return recoveryService.confirmRecoveryCode(request, authentication);
     }
 
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SecureVaultController.java
@@ -82,7 +82,8 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SecureVaultController.java
@@ -24,6 +24,8 @@ import io.getlime.security.powerauth.http.validator.InvalidPowerAuthHttpHeaderEx
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.service.v3.SecureVaultService;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
@@ -72,7 +74,7 @@ public class SecureVaultController {
                                               @Context HttpServletRequest httpServletRequest) throws PowerAuthAuthenticationException, PowerAuthSecureVaultException {
         if (request == null) {
             logger.warn("Invalid request object in vault unlock");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
 
         // Parse the header
@@ -82,17 +84,17 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.warn("Signature HTTP header validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthSignatureInvalidException(ex);
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
         if (request.getNonce() == null && !"3.0".equals(header.getVersion())) {
             logger.warn("Missing nonce in ECIES request data");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
         return secureVaultServiceV3.vaultUnlock(header, request, httpServletRequest);
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SecureVaultController.java
@@ -72,7 +72,7 @@ public class SecureVaultController {
                                               @Context HttpServletRequest httpServletRequest) throws PowerAuthAuthenticationException, PowerAuthSecureVaultException {
         if (request == null) {
             logger.warn("Invalid request object in vault unlock");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
 
         // Parse the header
@@ -83,16 +83,16 @@ public class SecureVaultController {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         if (request.getNonce() == null && !"3.0".equals(header.getVersion())) {
             logger.warn("Missing nonce in ECIES request data");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         return secureVaultServiceV3.vaultUnlock(header, request, httpServletRequest);
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
@@ -133,7 +133,8 @@ public class SignatureController {
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
@@ -124,7 +124,7 @@ public class SignatureController {
             if (authentication != null && authentication.getActivationId() != null) {
                 if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                     logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                    throw new PowerAuthAuthenticationException();
+                    throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
                 }
                 return new Response();
             } else {
@@ -134,7 +134,7 @@ public class SignatureController {
             throw ex;
         } catch (Exception ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_ERROR");
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
@@ -128,7 +128,7 @@ public class SignatureController {
                 }
                 return new Response();
             } else {
-                throw new PowerAuthAuthenticationException("Signature validation failed");
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/SignatureController.java
@@ -24,6 +24,9 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureErrorException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,20 +124,20 @@ public class SignatureController {
                             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
                     )
             );
-            if (authentication != null && authentication.getActivationId() != null) {
-                if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
-                    logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                    throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-                }
-                return new Response();
-            } else {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            if (authentication == null || authentication.getActivationId() == null) {
+                logger.debug("Signature validation failed");
+                throw new PowerAuthSignatureInvalidException();
             }
+            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
+                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+                throw new PowerAuthInvalidRequestException();
+            }
+            return new Response();
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_ERROR");
+            throw new PowerAuthSignatureErrorException(ex);
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/TokenController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/TokenController.java
@@ -26,6 +26,8 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.http.PowerAuthTokenHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.jaxrs.service.v3.TokenService;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -72,7 +74,7 @@ public class TokenController {
 
         if (request == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
         // Verify request signature before creating token
         PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature(
@@ -83,19 +85,19 @@ public class TokenController {
                         PowerAuthSignatureTypes.POSSESSION_BIOMETRY,
                         PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
                 ));
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
-                logger.warn("Missing nonce in ECIES request data");
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return tokenServiceV3.createToken(request, authentication);
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
+            logger.warn("Missing nonce in ECIES request data");
+            throw new PowerAuthInvalidRequestException();
+        }
+        return tokenServiceV3.createToken(request, authentication);
     }
 
     @POST
@@ -107,7 +109,7 @@ public class TokenController {
                                                            @HeaderParam(PowerAuthSignatureHttpHeader.HEADER_NAME) String authHeader) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in remove token");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
 
         // Verify request signature before removing token
@@ -120,15 +122,16 @@ public class TokenController {
                         PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
                 ));
 
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        TokenRemoveResponse response = tokenServiceV3.removeToken(request.getRequestObject(), authentication);
+        return new ObjectResponse<>(response);
     }
 
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/TokenController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/TokenController.java
@@ -72,7 +72,7 @@ public class TokenController {
 
         if (request == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         // Verify request signature before creating token
         PowerAuthApiAuthentication authentication = authenticationProvider.validateRequestSignature(
@@ -86,15 +86,15 @@ public class TokenController {
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
                 logger.warn("Missing nonce in ECIES request data");
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return tokenServiceV3.createToken(request, authentication);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 
@@ -107,7 +107,7 @@ public class TokenController {
                                                            @HeaderParam(PowerAuthSignatureHttpHeader.HEADER_NAME) String authHeader) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in remove token");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
 
         // Verify request signature before removing token
@@ -123,11 +123,11 @@ public class TokenController {
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
@@ -27,6 +27,7 @@ import io.getlime.security.powerauth.http.validator.PowerAuthEncryptionHttpHeade
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthUpgradeException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
 import io.getlime.security.powerauth.rest.api.jaxrs.service.v3.UpgradeService;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
@@ -89,8 +90,8 @@ public class UpgradeController {
         try {
             PowerAuthEncryptionHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Encryption validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthUpgradeException();
+            logger.warn("Encryption HTTP header validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthUpgradeException(ex);
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
@@ -127,13 +128,13 @@ public class UpgradeController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthUpgradeException();
+            logger.warn("Signature HTTP header validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthUpgradeException(ex);
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
 
         return upgradeService.upgradeCommit(signatureHeader, httpServletRequest);

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
@@ -133,7 +133,7 @@ public class UpgradeController {
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
 
         return upgradeService.upgradeCommit(signatureHeader, httpServletRequest);

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
@@ -89,7 +89,7 @@ public class UpgradeController {
         try {
             PowerAuthEncryptionHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            logger.warn("Encryption validation failed, error: {}", ex.getMessage());
             throw new PowerAuthUpgradeException();
         }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/controller/v3/UpgradeController.java
@@ -89,7 +89,8 @@ public class UpgradeController {
         try {
             PowerAuthEncryptionHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            throw new PowerAuthUpgradeException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthUpgradeException();
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
@@ -126,7 +127,8 @@ public class UpgradeController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            throw new PowerAuthUpgradeException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthUpgradeException();
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v2/SignatureTypeConverter.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v2/SignatureTypeConverter.java
@@ -21,6 +21,8 @@ package io.getlime.security.powerauth.rest.api.jaxrs.converter.v2;
 
 import com.wultra.security.powerauth.client.v2.PowerAuthPortV2ServiceStub;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to convert from and to
@@ -29,6 +31,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
  * @author Petr Dvorak, petr@wultra.com
  */
 public class SignatureTypeConverter {
+
+    private static final Logger logger = LoggerFactory.getLogger(SignatureTypeConverter.class);
 
     /**
      * Convert {@link com.wultra.security.powerauth.client.v2.PowerAuthPortV2ServiceStub.SignatureType}
@@ -47,7 +51,8 @@ public class SignatureTypeConverter {
         try {
             signatureTypeString = signatureTypeString.toUpperCase();
             return PowerAuthPortV2ServiceStub.SignatureType.Factory.fromValue(signatureTypeString);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid signature type, error: {}", ex.getMessage());
             // Return null value which represents an unknown signature type
             return null;
         }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v2/SignatureTypeConverter.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v2/SignatureTypeConverter.java
@@ -53,6 +53,7 @@ public class SignatureTypeConverter {
             return PowerAuthPortV2ServiceStub.SignatureType.Factory.fromValue(signatureTypeString);
         } catch (IllegalArgumentException ex) {
             logger.warn("Invalid signature type, error: {}", ex.getMessage());
+            logger.debug("Error details", ex);
             // Return null value which represents an unknown signature type
             return null;
         }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v3/SignatureTypeConverter.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v3/SignatureTypeConverter.java
@@ -53,6 +53,7 @@ public class SignatureTypeConverter {
             return PowerAuthPortV3ServiceStub.SignatureType.Factory.fromValue(signatureTypeString);
         } catch (IllegalArgumentException ex) {
             logger.warn("Invalid signature type, error: {}", ex.getMessage());
+            logger.debug("Error details", ex);
             // Return null value which represents an unknown signature type
             return null;
         }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v3/SignatureTypeConverter.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/converter/v3/SignatureTypeConverter.java
@@ -21,6 +21,8 @@ package io.getlime.security.powerauth.rest.api.jaxrs.converter.v3;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthPortV3ServiceStub;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to convert from and to
@@ -29,6 +31,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
  * @author Petr Dvorak, petr@wultra.com
  */
 public class SignatureTypeConverter {
+
+    private static final Logger logger = LoggerFactory.getLogger(SignatureTypeConverter.class);
 
     /**
      * Convert {@link PowerAuthPortV3ServiceStub.SignatureType}
@@ -47,7 +51,8 @@ public class SignatureTypeConverter {
         try {
             signatureTypeString = signatureTypeString.toUpperCase();
             return PowerAuthPortV3ServiceStub.SignatureType.Factory.fromValue(signatureTypeString);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid signature type, error: {}", ex.getMessage());
             // Return null value which represents an unknown signature type
             return null;
         }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
@@ -250,7 +250,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             auth = this.authenticate(powerAuthAuthentication);
         } catch (RemoteException ex) {
             logger.warn("Remote communication failed, error: {}", ex.getMessage());
-            throw new PowerAuthSignatureErrorException();
+            throw new PowerAuthSignatureErrorException(ex);
         }
 
         // In case authentication is null, throw PowerAuth exception

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
@@ -271,7 +271,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
         try {
             PowerAuthTokenHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            logger.warn("Token validation failed, error: {}", ex.getMessage());
             throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
@@ -245,7 +245,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             auth = this.authenticate(powerAuthAuthentication);
         } catch (RemoteException ex) {
             logger.warn("Remote communication failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_SOAP_ERROR");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_REMOTE_ERROR");
         }
 
         // In case authentication is null, throw PowerAuth exception
@@ -272,7 +272,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             PowerAuthTokenHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
             logger.warn("Token validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_INVALID");
         }
 
         // Prepare authentication object
@@ -290,7 +290,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             auth = this.authenticate(powerAuthTokenAuthentication);
         } catch (RemoteException ex) {
             logger.warn("Remote communication failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_SOAP_ERROR");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_REMOTE_ERROR");
         }
 
         // In case authentication is null, throw PowerAuth exception

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthAuthenticationProvider.java
@@ -152,8 +152,8 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             } else {
                 return null;
             }
-        } catch (Exception e) {
-            logger.warn("Token validation failed", e);
+        } catch (Exception ex) {
+            logger.warn("Token validation failed, error: {}", ex.getMessage());
             return null;
         }
     }
@@ -214,9 +214,9 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
         // Validate the header
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
-        } catch (InvalidPowerAuthHttpHeaderException e) {
-            logger.warn(e.getMessage(), e);
-            throw new PowerAuthAuthenticationException(e.getMessage());
+        } catch (InvalidPowerAuthHttpHeaderException ex) {
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         // Check if the signature type is allowed
@@ -243,7 +243,8 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
         PowerAuthApiAuthentication auth;
         try {
             auth = this.authenticate(powerAuthAuthentication);
-        } catch (RemoteException e) {
+        } catch (RemoteException ex) {
+            logger.warn("Remote communication failed, error: {}", ex.getMessage());
             throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_SOAP_ERROR");
         }
 
@@ -269,9 +270,9 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
         // Validate the header
         try {
             PowerAuthTokenHttpHeaderValidator.validate(header);
-        } catch (InvalidPowerAuthHttpHeaderException e) {
-            logger.warn(e.getMessage(), e);
-            throw new PowerAuthAuthenticationException(e.getMessage());
+        } catch (InvalidPowerAuthHttpHeaderException ex) {
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         // Prepare authentication object
@@ -287,7 +288,8 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
         final PowerAuthApiAuthentication auth;
         try {
             auth = this.authenticate(powerAuthTokenAuthentication);
-        } catch (RemoteException e) {
+        } catch (RemoteException ex) {
+            logger.warn("Remote communication failed, error: {}", ex.getMessage());
             throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_SOAP_ERROR");
         }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthEncryptionProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthEncryptionProvider.java
@@ -56,7 +56,7 @@ public class PowerAuthEncryptionProvider extends PowerAuthEncryptionProviderBase
             return new PowerAuthEciesDecryptorParameters(eciesDecryptorResponse.getSecretKey(), eciesDecryptorResponse.getSharedInfo2());
         } catch (RemoteException ex) {
             logger.warn("Get ECIES decryptor call failed, error: {}", ex.getMessage());
-            throw new PowerAuthEncryptionException();
+            throw new PowerAuthEncryptionException(ex);
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthEncryptionProvider.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/provider/PowerAuthEncryptionProvider.java
@@ -54,8 +54,8 @@ public class PowerAuthEncryptionProvider extends PowerAuthEncryptionProviderBase
             eciesDecryptorRequest.setEphemeralPublicKey(ephemeralPublicKey);
             PowerAuthPortV3ServiceStub.GetEciesDecryptorResponse eciesDecryptorResponse = powerAuthClient.getEciesDecryptor(eciesDecryptorRequest);
             return new PowerAuthEciesDecryptorParameters(eciesDecryptorResponse.getSecretKey(), eciesDecryptorResponse.getSharedInfo2());
-        } catch (RemoteException e) {
-            logger.warn("Get Ecies decryptor parameters call failed", e);
+        } catch (RemoteException ex) {
+            logger.warn("Get ECIES decryptor call failed, error: {}", ex.getMessage());
             throw new PowerAuthEncryptionException();
         }
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/ActivationService.java
@@ -88,7 +88,7 @@ public class ActivationService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/ActivationService.java
@@ -87,7 +87,7 @@ public class ActivationService {
 
             return response;
         } catch (Exception ex) {
-            logger.warn("Creating PowerAuth activation failed", ex);
+            logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/SecureVaultService.java
@@ -81,8 +81,9 @@ public class SecureVaultService {
             // Validate the header
             try {
                 PowerAuthSignatureHttpHeaderValidator.validate(header);
-            } catch (InvalidPowerAuthHttpHeaderException e) {
-                throw new PowerAuthAuthenticationException(e.getMessage());
+            } catch (InvalidPowerAuthHttpHeaderException ex) {
+                logger.warn("Signature validation failed, error: {}", ex.getMessage());
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
 
             SignatureTypeConverter converter = new SignatureTypeConverter();
@@ -134,7 +135,7 @@ public class SecureVaultService {
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
-            logger.warn("PowerAuth vault unlock failed", ex);
+            logger.warn("PowerAuth vault unlock failed, error: {}", ex.getMessage());
             throw new PowerAuthSecureVaultException();
         }
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/SecureVaultService.java
@@ -27,6 +27,8 @@ import io.getlime.security.powerauth.http.validator.InvalidPowerAuthHttpHeaderEx
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureTypeInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.converter.v2.SignatureTypeConverter;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.model.request.v2.VaultUnlockRequest;
@@ -82,8 +84,8 @@ public class SecureVaultService {
             try {
                 PowerAuthSignatureHttpHeaderValidator.validate(header);
             } catch (InvalidPowerAuthHttpHeaderException ex) {
-                logger.warn("Signature validation failed, error: {}", ex.getMessage());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+                logger.warn("Signature HTTP header validation failed, error: {}", ex.getMessage());
+                throw new PowerAuthSignatureInvalidException(ex);
             }
 
             SignatureTypeConverter converter = new SignatureTypeConverter();
@@ -93,7 +95,8 @@ public class SecureVaultService {
             String signature = header.getSignature();
             PowerAuthPortV2ServiceStub.SignatureType signatureType = converter.convertFrom(header.getSignatureType());
             if (signatureType == null) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+                logger.warn("Invalid signature type: {}", header.getSignatureType());
+                throw new PowerAuthSignatureTypeInvalidException();
             }
 
             String nonce = header.getNonce();
@@ -116,6 +119,7 @@ public class SecureVaultService {
                 // Use POST request body as data for signature.
                 requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
             } else {
+                logger.warn("Invalid protocol version in secure vault: {}", header.getVersion());
                 throw new PowerAuthSecureVaultException();
             }
 
@@ -124,7 +128,8 @@ public class SecureVaultService {
             PowerAuthPortV2ServiceStub.VaultUnlockResponse soapResponse = powerAuthClient.v2().unlockVault(activationId, applicationId, data, signature, signatureType, reason);
 
             if (!soapResponse.getSignatureValid()) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+                logger.debug("Signature validation failed");
+                throw new PowerAuthSignatureInvalidException();
             }
 
             VaultUnlockResponse response = new VaultUnlockResponse();
@@ -136,7 +141,7 @@ public class SecureVaultService {
             throw ex;
         } catch (Exception ex) {
             logger.warn("PowerAuth vault unlock failed, error: {}", ex.getMessage());
-            throw new PowerAuthSecureVaultException();
+            throw new PowerAuthSecureVaultException(ex);
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/SecureVaultService.java
@@ -124,7 +124,7 @@ public class SecureVaultService {
             PowerAuthPortV2ServiceStub.VaultUnlockResponse soapResponse = powerAuthClient.v2().unlockVault(activationId, applicationId, data, signature, signatureType, reason);
 
             if (!soapResponse.getSignatureValid()) {
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
 
             VaultUnlockResponse response = new VaultUnlockResponse();

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/TokenService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/TokenService.java
@@ -87,8 +87,8 @@ public class TokenService {
             response.setEncryptedData(token.getEncryptedData());
             return response;
         } catch (Exception ex) {
-            logger.warn("Creating PowerAuth token failed", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/TokenService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/TokenService.java
@@ -88,7 +88,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/TokenService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v2/TokenService.java
@@ -23,6 +23,8 @@ import com.wultra.security.powerauth.client.v2.PowerAuthPortV2ServiceStub;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureTypeInvalidException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthTokenErrorException;
 import io.getlime.security.powerauth.rest.api.jaxrs.converter.v2.SignatureTypeConverter;
 import io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.TokenCreateResponse;
@@ -75,7 +77,8 @@ public class TokenService {
             // Convert signature type
             PowerAuthPortV2ServiceStub.SignatureType signatureType = converter.convertFrom(signatureFactors);
             if (signatureType == null) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+                logger.warn("Invalid signature type: {}", signatureFactors);
+                throw new PowerAuthSignatureTypeInvalidException();
             }
 
             // Create a token
@@ -88,7 +91,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
+            throw new PowerAuthTokenErrorException(ex);
         }
     }
 

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
@@ -254,21 +254,21 @@ public class ActivationService {
                 }
 
                 default:
-                    throw new PowerAuthAuthenticationException("Unsupported activation type: " + request.getType());
+                    throw new PowerAuthAuthenticationException();
             }
         } catch (AxisFault ex) {
             if (ex.getFaultDetailElement() != null) {
                 handleInvalidRecoveryError(ex.getFaultDetailElement());
             }
-            logger.warn("Creating PowerAuth activation failed", ex);
+            logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         } catch (PowerAuthActivationException ex) {
             // Do not swallow PowerAuthActivationException for custom activations.
             // See: https://github.com/wultra/powerauth-restful-integration/issues/199
-            logger.warn("Creating PowerAuth activation failed", ex);
+            logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
             throw ex;
         } catch (Exception ex) {
-            logger.warn("Creating PowerAuth activation failed", ex);
+            logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }
@@ -294,7 +294,7 @@ public class ActivationService {
             }
             return response;
         } catch (Exception ex) {
-            logger.warn("PowerAuth activation status check failed", ex);
+            logger.warn("PowerAuth activation status check failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }
@@ -329,7 +329,7 @@ public class ActivationService {
             response.setActivationId(soapResponse.getActivationId());
             return response;
         } catch (Exception ex) {
-            logger.warn("PowerAuth activation removal failed", ex);
+            logger.warn("PowerAuth activation removal failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }
@@ -357,6 +357,7 @@ public class ActivationService {
                     try {
                         currentRecoveryPukIndex = Integer.parseInt(node.getText());
                     } catch (NumberFormatException ex) {
+                        logger.warn("Invalid puk index, error: {}", ex.getMessage());
                         // Ignore invalid index
                     }
                     break;

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
@@ -24,8 +24,8 @@ import io.getlime.security.powerauth.rest.api.base.application.PowerAuthApplicat
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncryption;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
-import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthRecoveryException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
 import io.getlime.security.powerauth.rest.api.base.provider.CustomActivationProvider;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
@@ -93,6 +93,7 @@ public class ActivationService {
 
             // Validate inner encryption
             if (nonce == null && !"3.0".equals(eciesEncryption.getContext().getVersion())) {
+                logger.warn("Missing nonce for protocol version: {}", eciesEncryption.getContext().getVersion());
                 throw new PowerAuthActivationException();
             }
 
@@ -139,6 +140,7 @@ public class ActivationService {
                 case CUSTOM: {
                     // Check if there is a custom activation provider available, return an error in case it is not available
                     if (activationProvider == null) {
+                        logger.warn("Activation provider is missing");
                         throw new PowerAuthActivationException();
                     }
 
@@ -147,6 +149,7 @@ public class ActivationService {
 
                     // If no user was found or user ID is invalid, return an error
                     if (userId == null || userId.equals("") || userId.length() > 255) {
+                        logger.warn("User ID is invalid: {}", userId);
                         throw new PowerAuthActivationException();
                     }
 
@@ -206,6 +209,7 @@ public class ActivationService {
                 case RECOVERY: {
 
                     if (request.getIdentityAttributes() == null) {
+                        logger.warn("Identity attributes are missing");
                         throw new PowerAuthActivationException();
                     }
 
@@ -214,10 +218,12 @@ public class ActivationService {
                     String recoveryPuk = request.getIdentityAttributes().get("puk");
 
                     if (recoveryCode == null || recoveryCode.isEmpty()) {
+                        logger.warn("Recovery code is missing");
                         throw new PowerAuthActivationException();
                     }
 
                     if (recoveryPuk == null || recoveryPuk.isEmpty()) {
+                        logger.warn("Recovery PUK is missing");
                         throw new PowerAuthActivationException();
                     }
 
@@ -254,14 +260,15 @@ public class ActivationService {
                 }
 
                 default:
-                    throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+                    logger.warn("Invalid activation request");
+                    throw new PowerAuthInvalidRequestException();
             }
         } catch (AxisFault ex) {
             if (ex.getFaultDetailElement() != null) {
                 handleInvalidRecoveryError(ex.getFaultDetailElement());
             }
             logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         } catch (PowerAuthActivationException ex) {
             // Do not swallow PowerAuthActivationException for custom activations.
             // See: https://github.com/wultra/powerauth-restful-integration/issues/199
@@ -269,7 +276,7 @@ public class ActivationService {
             throw ex;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
     }
 
@@ -295,7 +302,7 @@ public class ActivationService {
             return response;
         } catch (Exception ex) {
             logger.warn("PowerAuth activation status check failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
     }
 
@@ -330,7 +337,7 @@ public class ActivationService {
             return response;
         } catch (Exception ex) {
             logger.warn("PowerAuth activation removal failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
     }
 
@@ -358,12 +365,14 @@ public class ActivationService {
                         currentRecoveryPukIndex = Integer.parseInt(node.getText());
                     } catch (NumberFormatException ex) {
                         logger.warn("Invalid puk index, error: {}", ex.getMessage());
+                        logger.debug("Error details", ex);
                         // Ignore invalid index
                     }
                     break;
             }
         }
         if ("ERR0028".equals(errorCode)) {
+            logger.debug("Invalid recovery code, current PUK index: {}", currentRecoveryPukIndex);
             throw new PowerAuthRecoveryException(errorMessage, "INVALID_RECOVERY_CODE", currentRecoveryPukIndex);
         }
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/ActivationService.java
@@ -254,7 +254,7 @@ public class ActivationService {
                 }
 
                 default:
-                    throw new PowerAuthAuthenticationException();
+                    throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
         } catch (AxisFault ex) {
             if (ex.getFaultDetailElement() != null) {

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/RecoveryService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/RecoveryService.java
@@ -65,18 +65,18 @@ public class RecoveryService {
             final String applicationKey = httpHeader.getApplicationKey();
             if (activationId == null || applicationKey == null || request.getEphemeralPublicKey() == null
                     || request.getEncryptedData() == null || request.getMac() == null) {
-                logger.error("PowerAuth confirm recovery failed because of invalid request");
+                logger.warn("PowerAuth confirm recovery failed because of invalid request");
                 throw new PowerAuthAuthenticationException();
             }
             PowerAuthPortV3ServiceStub.ConfirmRecoveryCodeResponse paResponse = powerAuthClient.confirmRecoveryCode(activationId, applicationKey,
                     request.getEphemeralPublicKey(), request.getEncryptedData(), request.getMac(), request.getNonce());
             if (!paResponse.getActivationId().equals(activationId)) {
-                logger.error("PowerAuth confirm recovery failed because of invalid activation ID in response");
+                logger.warn("PowerAuth confirm recovery failed because of invalid activation ID in response");
                 throw new PowerAuthAuthenticationException();
             }
             return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac());
         } catch (Exception ex) {
-            logger.warn("PowerAuth confirm recovery failed", ex);
+            logger.warn("PowerAuth confirm recovery failed, error: {}", ex.getMessage());
             throw new PowerAuthAuthenticationException();
         }
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/RecoveryService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/RecoveryService.java
@@ -66,18 +66,18 @@ public class RecoveryService {
             if (activationId == null || applicationKey == null || request.getEphemeralPublicKey() == null
                     || request.getEncryptedData() == null || request.getMac() == null) {
                 logger.warn("PowerAuth confirm recovery failed because of invalid request");
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             PowerAuthPortV3ServiceStub.ConfirmRecoveryCodeResponse paResponse = powerAuthClient.confirmRecoveryCode(activationId, applicationKey,
                     request.getEphemeralPublicKey(), request.getEncryptedData(), request.getMac(), request.getNonce());
             if (!paResponse.getActivationId().equals(activationId)) {
                 logger.warn("PowerAuth confirm recovery failed because of invalid activation ID in response");
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac());
         } catch (Exception ex) {
             logger.warn("PowerAuth confirm recovery failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_RECOVERY_ERROR");
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/RecoveryService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/RecoveryService.java
@@ -23,6 +23,8 @@ import com.wultra.security.powerauth.client.v3.PowerAuthPortV3ServiceStub;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthRecoveryConfirmationException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.soap.axis.client.PowerAuthServiceClient;
@@ -66,18 +68,18 @@ public class RecoveryService {
             if (activationId == null || applicationKey == null || request.getEphemeralPublicKey() == null
                     || request.getEncryptedData() == null || request.getMac() == null) {
                 logger.warn("PowerAuth confirm recovery failed because of invalid request");
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+                throw new PowerAuthInvalidRequestException();
             }
             PowerAuthPortV3ServiceStub.ConfirmRecoveryCodeResponse paResponse = powerAuthClient.confirmRecoveryCode(activationId, applicationKey,
                     request.getEphemeralPublicKey(), request.getEncryptedData(), request.getMac(), request.getNonce());
             if (!paResponse.getActivationId().equals(activationId)) {
                 logger.warn("PowerAuth confirm recovery failed because of invalid activation ID in response");
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+                throw new PowerAuthInvalidRequestException();
             }
             return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac());
         } catch (Exception ex) {
             logger.warn("PowerAuth confirm recovery failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_RECOVERY_ERROR");
+            throw new PowerAuthRecoveryConfirmationException(ex);
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
@@ -107,7 +107,7 @@ public class SecureVaultService {
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
-            logger.warn("PowerAuth vault unlock failed", ex);
+            logger.warn("PowerAuth vault unlock failed, error: {}", ex.getMessage());
             throw new PowerAuthSecureVaultException();
         }
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
@@ -100,7 +100,7 @@ public class SecureVaultService {
                     signatureType, signatureVersion, data, ephemeralPublicKey, encryptedData, mac, eciesNonce);
 
             if (!soapResponse.getSignatureValid()) {
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
 
             return new EciesEncryptedResponse(soapResponse.getEncryptedData(), soapResponse.getMac());

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/SecureVaultService.java
@@ -25,6 +25,8 @@ import io.getlime.security.powerauth.http.PowerAuthHttpBody;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureTypeInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.converter.v3.SignatureTypeConverter;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
@@ -79,7 +81,8 @@ public class SecureVaultService {
             String signature = header.getSignature();
             PowerAuthPortV3ServiceStub.SignatureType signatureType = converter.convertFrom(header.getSignatureType());
             if (signatureType == null) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+                logger.warn("Invalid signature type: {}", header.getSignatureType());
+                throw new PowerAuthSignatureTypeInvalidException();
             }
 
             String signatureVersion = header.getVersion();
@@ -100,7 +103,8 @@ public class SecureVaultService {
                     signatureType, signatureVersion, data, ephemeralPublicKey, encryptedData, mac, eciesNonce);
 
             if (!soapResponse.getSignatureValid()) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+                logger.debug("Signature validation failed");
+                throw new PowerAuthSignatureInvalidException();
             }
 
             return new EciesEncryptedResponse(soapResponse.getEncryptedData(), soapResponse.getMac());
@@ -108,7 +112,7 @@ public class SecureVaultService {
             throw ex;
         } catch (Exception ex) {
             logger.warn("PowerAuth vault unlock failed, error: {}", ex.getMessage());
-            throw new PowerAuthSecureVaultException();
+            throw new PowerAuthSecureVaultException(ex);
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/TokenService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/TokenService.java
@@ -99,8 +99,8 @@ public class TokenService {
             response.setEncryptedData(token.getEncryptedData());
             return response;
         } catch (Exception ex) {
-            logger.warn("Creating PowerAuth token failed", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
     }
 
@@ -128,8 +128,8 @@ public class TokenService {
             response.setTokenId(tokenId);
             return response;
         } catch (Exception ex) {
-            logger.warn("Removing PowerAuth token failed", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Removing PowerAuth token failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/TokenService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/TokenService.java
@@ -100,7 +100,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
         }
     }
 
@@ -129,7 +129,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Removing PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/TokenService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/TokenService.java
@@ -24,6 +24,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureTypeInvalidException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthTokenErrorException;
 import io.getlime.security.powerauth.rest.api.jaxrs.converter.v3.SignatureTypeConverter;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveRequest;
@@ -81,7 +83,8 @@ public class TokenService {
             // Convert signature type
             PowerAuthPortV3ServiceStub.SignatureType signatureType = converter.convertFrom(signatureFactors);
             if (signatureType == null) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+                logger.warn("Invalid signature type: {}", signatureFactors);
+                throw new PowerAuthSignatureTypeInvalidException();
             }
 
             // Get ECIES headers
@@ -100,7 +103,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
+            throw new PowerAuthTokenErrorException(ex);
         }
     }
 
@@ -129,7 +132,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Removing PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
+            throw new PowerAuthTokenErrorException(ex);
         }
     }
 }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/UpgradeService.java
@@ -123,7 +123,7 @@ public class UpgradeService {
 
             // In case signature verification fails, upgrade fails, too
             if (authentication == null || authentication.getActivationId() == null) {
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
 
             // Get signature HTTP headers

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/UpgradeService.java
@@ -92,7 +92,7 @@ public class UpgradeService {
             response.setEncryptedData(upgradeResponse.getEncryptedData());
             return response;
         } catch (Exception ex) {
-            logger.warn("PowerAuth upgrade start failed", ex);
+            logger.warn("PowerAuth upgrade start failed, error: {}", ex.getMessage());
             throw new PowerAuthUpgradeException();
         }
     }
@@ -142,7 +142,7 @@ public class UpgradeService {
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
-            logger.warn("PowerAuth upgrade commit failed", ex);
+            logger.warn("PowerAuth upgrade commit failed, error: {}", ex.getMessage());
             throw new PowerAuthUpgradeException();
         }
     }

--- a/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-javaee/src/main/java/io/getlime/security/powerauth/rest/api/jaxrs/service/v3/UpgradeService.java
@@ -114,7 +114,7 @@ public class UpgradeService {
             byte[] requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
             if (requestBodyBytes == null || requestBodyBytes.length == 0) {
                 // Expected request body is {}, do not accept empty body
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
 
             // Verify signature, force signature version during upgrade to version 3

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthAnnotationInterceptor.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthAnnotationInterceptor.java
@@ -90,6 +90,7 @@ public class PowerAuthAnnotationInterceptor extends HandlerInterceptorAdapter {
                     // Encryption object is saved in HTTP servlet request by encryption provider, so that it is available for both Spring and Java EE
                 } catch (PowerAuthEncryptionException ex) {
                     logger.warn("Decryption failed, error: {}", ex.getMessage());
+                    logger.debug("Error details", ex);
                 }
             }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthAnnotationInterceptor.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthAnnotationInterceptor.java
@@ -76,7 +76,7 @@ public class PowerAuthAnnotationInterceptor extends HandlerInterceptorAdapter {
 
             // Check that either signature or token annotation is active
             if (powerAuthSignatureAnnotation != null && powerAuthTokenAnnotation != null) {
-                logger.error("You cannot use both @PowerAuth and @PowerAuthToken on same handler method. We are removing both.");
+                logger.warn("You cannot use both @PowerAuth and @PowerAuthToken on same handler method. We are removing both.");
                 powerAuthSignatureAnnotation = null;
                 powerAuthTokenAnnotation = null;
             }
@@ -89,7 +89,7 @@ public class PowerAuthAnnotationInterceptor extends HandlerInterceptorAdapter {
                     encryptionProvider.decryptRequest(request, requestType, powerAuthEncryptionAnnotation.scope());
                     // Encryption object is saved in HTTP servlet request by encryption provider, so that it is available for both Spring and Java EE
                 } catch (PowerAuthEncryptionException ex) {
-                    // Silently ignore errors
+                    logger.warn("Decryption failed, error: {}", ex.getMessage());
                 }
             }
 
@@ -105,7 +105,7 @@ public class PowerAuthAnnotationInterceptor extends HandlerInterceptorAdapter {
                     );
                     request.setAttribute(PowerAuthRequestObjects.AUTHENTICATION_OBJECT, authentication);
                 } catch (PowerAuthAuthenticationException ex) {
-                    // Silently ignore here and make sure authentication object is null
+                    logger.warn("Invalid request signature, authentication object was removed");
                     request.setAttribute(PowerAuthRequestObjects.AUTHENTICATION_OBJECT, null);
                 }
 
@@ -120,7 +120,7 @@ public class PowerAuthAnnotationInterceptor extends HandlerInterceptorAdapter {
                     );
                     request.setAttribute(PowerAuthRequestObjects.AUTHENTICATION_OBJECT, authentication);
                 } catch (PowerAuthAuthenticationException ex) {
-                    // Silently ignore here and make sure authentication object is null
+                    logger.warn("Invalid token, authentication object was removed");
                     request.setAttribute(PowerAuthRequestObjects.AUTHENTICATION_OBJECT, null);
                 }
             }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthEncryptionArgumentResolver.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthEncryptionArgumentResolver.java
@@ -65,7 +65,8 @@ public class PowerAuthEncryptionArgumentResolver implements HandlerMethodArgumen
             } else {
                 try {
                     return objectMapper.readValue(eciesObject.getDecryptedRequest(), parameterType);
-                } catch (IOException e) {
+                } catch (IOException ex) {
+                    logger.warn("Invalid request, error: {}", ex.getMessage());
                     return null;
                 }
             }
@@ -110,7 +111,7 @@ public class PowerAuthEncryptionArgumentResolver implements HandlerMethodArgumen
                 break;
 
             default:
-                logger.error("Unsupported ECIES scope: {}", eciesContext.getEciesScope());
+                logger.warn("Unsupported ECIES scope: {}", eciesContext.getEciesScope());
                 return false;
         }
         return true;

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthEncryptionArgumentResolver.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/PowerAuthEncryptionArgumentResolver.java
@@ -67,6 +67,7 @@ public class PowerAuthEncryptionArgumentResolver implements HandlerMethodArgumen
                     return objectMapper.readValue(eciesObject.getDecryptedRequest(), parameterType);
                 } catch (IOException ex) {
                     logger.warn("Invalid request, error: {}", ex.getMessage());
+                    logger.debug("Error details", ex);
                     return null;
                 }
             }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v2/SignatureTypeConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v2/SignatureTypeConverter.java
@@ -53,6 +53,7 @@ public class SignatureTypeConverter {
         } catch (IllegalArgumentException ex) {
             logger.warn("Invalid signature type, error: {}", ex.getMessage());
             logger.debug("Error details", ex);
+            // Return null value which represents an unknown signature type
             return null;
         }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v2/SignatureTypeConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v2/SignatureTypeConverter.java
@@ -21,6 +21,8 @@ package io.getlime.security.powerauth.rest.api.spring.converter.v2;
 
 import com.wultra.security.powerauth.client.v2.SignatureType;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to convert from and to
@@ -30,6 +32,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
  */
 public class SignatureTypeConverter {
 
+    private static final Logger logger = LoggerFactory.getLogger(SignatureTypeConverter.class);
+
     /**
      * Convert {@link com.wultra.security.powerauth.client.v2.SignatureType}
      * from a {@link String} value.
@@ -38,17 +42,17 @@ public class SignatureTypeConverter {
      */
     public SignatureType convertFrom(String signatureTypeString) {
 
-        // Default to strongest signature type on null value
         if (signatureTypeString == null) {
-            return SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+            return null;
         }
 
         // Try to convert signature type
         try {
             signatureTypeString = signatureTypeString.toUpperCase();
             return SignatureType.fromValue(signatureTypeString);
-        } catch (IllegalArgumentException e) {
-            return SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid signature type, error: {}", ex.getMessage());
+            return null;
         }
 
     }
@@ -71,7 +75,7 @@ public class SignatureTypeConverter {
             case POSSESSION_BIOMETRY:
                 return SignatureType.POSSESSION_BIOMETRY;
             default:
-                return SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+                return null;
         }
     }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v2/SignatureTypeConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v2/SignatureTypeConverter.java
@@ -52,6 +52,7 @@ public class SignatureTypeConverter {
             return SignatureType.fromValue(signatureTypeString);
         } catch (IllegalArgumentException ex) {
             logger.warn("Invalid signature type, error: {}", ex.getMessage());
+            logger.debug("Error details", ex);
             return null;
         }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v3/SignatureTypeConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v3/SignatureTypeConverter.java
@@ -53,6 +53,7 @@ public class SignatureTypeConverter {
         } catch (IllegalArgumentException ex) {
             logger.warn("Invalid signature type, error: {}", ex.getMessage());
             logger.debug("Error details", ex);
+            // Return null value which represents an unknown signature type
             return null;
         }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v3/SignatureTypeConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v3/SignatureTypeConverter.java
@@ -21,6 +21,8 @@ package io.getlime.security.powerauth.rest.api.spring.converter.v3;
 
 import com.wultra.security.powerauth.client.v3.SignatureType;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to convert from and to
@@ -30,6 +32,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
  */
 public class SignatureTypeConverter {
 
+    private static final Logger logger = LoggerFactory.getLogger(SignatureTypeConverter.class);
+
     /**
      * Convert {@link com.wultra.security.powerauth.client.v3.SignatureType}
      * from a {@link String} value.
@@ -38,17 +42,17 @@ public class SignatureTypeConverter {
      */
     public SignatureType convertFrom(String signatureTypeString) {
 
-        // Default to strongest signature type on null value
         if (signatureTypeString == null) {
-            return SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+            return null;
         }
 
         // Try to convert signature type
         try {
             signatureTypeString = signatureTypeString.toUpperCase();
             return SignatureType.fromValue(signatureTypeString);
-        } catch (IllegalArgumentException e) {
-            return SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid signature type, error: {}", ex.getMessage());
+            return null;
         }
 
     }
@@ -71,7 +75,7 @@ public class SignatureTypeConverter {
             case POSSESSION_BIOMETRY:
                 return SignatureType.POSSESSION_BIOMETRY;
             default:
-                return SignatureType.POSSESSION_KNOWLEDGE_BIOMETRY;
+                return null;
         }
     }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v3/SignatureTypeConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/converter/v3/SignatureTypeConverter.java
@@ -52,6 +52,7 @@ public class SignatureTypeConverter {
             return SignatureType.fromValue(signatureTypeString);
         } catch (IllegalArgumentException ex) {
             logger.warn("Invalid signature type, error: {}", ex.getMessage());
+            logger.debug("Error details", ex);
             return null;
         }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/EncryptorFactory.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/EncryptorFactory.java
@@ -85,8 +85,8 @@ public class EncryptorFactory {
                     encryptionKeyResponse.getEphemeralPublicKey()
             );
         } catch (PowerAuthClientException ex) {
-            logger.warn(ex.getMessage(), ex);
-            throw new PowerAuthEncryptionException(ex.getMessage());
+            logger.warn("Encryption failed, error: {}", ex.getMessage());
+            throw new PowerAuthEncryptionException();
         }
     }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/EncryptorFactory.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/EncryptorFactory.java
@@ -86,7 +86,7 @@ public class EncryptorFactory {
             );
         } catch (PowerAuthClientException ex) {
             logger.warn("Encryption failed, error: {}", ex.getMessage());
-            throw new PowerAuthEncryptionException();
+            throw new PowerAuthEncryptionException(ex);
         }
     }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/EncryptionResponseBodyAdvice.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/EncryptionResponseBodyAdvice.java
@@ -136,6 +136,7 @@ public class EncryptionResponseBodyAdvice implements ResponseBodyAdvice<Object> 
             }
         } catch (Exception ex) {
             logger.warn("Encryption failed, error: {}", ex.getMessage());
+            logger.debug("Error details", ex);
             return null;
         }
     }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/EncryptionResponseBodyAdvice.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/EncryptionResponseBodyAdvice.java
@@ -27,6 +27,8 @@ import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncr
 import io.getlime.security.powerauth.rest.api.base.model.PowerAuthRequestObjects;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuthEncryption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -58,6 +60,8 @@ import java.util.List;
  */
 @ControllerAdvice
 public class EncryptionResponseBodyAdvice implements ResponseBodyAdvice<Object> {
+
+    private static final Logger logger = LoggerFactory.getLogger(EncryptionResponseBodyAdvice.class);
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -131,6 +135,7 @@ public class EncryptionResponseBodyAdvice implements ResponseBodyAdvice<Object> 
                 return convertEncryptedResponse(encryptedResponse, mediaType);
             }
         } catch (Exception ex) {
+            logger.warn("Encryption failed, error: {}", ex.getMessage());
             return null;
         }
     }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
@@ -278,7 +278,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
         try {
             PowerAuthTokenHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            logger.warn("Token validation failed, error: {}", ex.getMessage());
             throw new PowerAuthAuthenticationException();
         }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
@@ -230,7 +230,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         // Check if the signature type is allowed

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
@@ -99,6 +99,9 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
 
             SignatureTypeConverter converter = new SignatureTypeConverter();
             final SignatureType signatureType = converter.convertFrom(authentication.getSignatureType());
+            if (signatureType == null) {
+                return null;
+            }
 
             VerifySignatureRequest request = new VerifySignatureRequest();
             request.setActivationId(authentication.getActivationId());
@@ -123,6 +126,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             try {
                 response = powerAuthClient.verifySignature(request);
             } catch (PowerAuthClientException ex) {
+                logger.error("Signature validation failed, error: {}", ex.getMessage());
                 return null;
             }
             if (response.isSignatureValid()) {
@@ -161,8 +165,8 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             } else {
                 return null;
             }
-        } catch (Exception e) {
-            logger.warn("Token validation failed", e);
+        } catch (Exception ex) {
+            logger.warn("Token validation failed, error: {}", ex.getMessage());
             return null;
         }
     }
@@ -224,9 +228,9 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
         // Validate the header
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
-        } catch (InvalidPowerAuthHttpHeaderException e) {
-            logger.error(e.getMessage(), e);
-            throw new PowerAuthAuthenticationException(e.getMessage());
+        } catch (InvalidPowerAuthHttpHeaderException ex) {
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
 
         // Check if the signature type is allowed
@@ -273,9 +277,9 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
         // Validate the header
         try {
             PowerAuthTokenHttpHeaderValidator.validate(header);
-        } catch (InvalidPowerAuthHttpHeaderException e) {
-            logger.warn(e.getMessage(), e);
-            throw new PowerAuthAuthenticationException(e.getMessage());
+        } catch (InvalidPowerAuthHttpHeaderException ex) {
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
 
         // Prepare authentication object

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
@@ -279,7 +279,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             PowerAuthTokenHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
             logger.warn("Token validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_INVALID");
         }
 
         // Prepare authentication object

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProvider.java
@@ -59,7 +59,7 @@ public class PowerAuthEncryptionProvider extends PowerAuthEncryptionProviderBase
             return new PowerAuthEciesDecryptorParameters(eciesDecryptorResponse.getSecretKey(), eciesDecryptorResponse.getSharedInfo2());
         } catch (Exception ex) {
             logger.warn("Get ECIES decryptor call failed, error: {}", ex.getMessage());
-            throw new PowerAuthEncryptionException();
+            throw new PowerAuthEncryptionException(ex);
         }
     }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProvider.java
@@ -57,8 +57,8 @@ public class PowerAuthEncryptionProvider extends PowerAuthEncryptionProviderBase
             eciesDecryptorRequest.setEphemeralPublicKey(ephemeralPublicKey);
             GetEciesDecryptorResponse eciesDecryptorResponse = powerAuthClient.getEciesDecryptor(eciesDecryptorRequest);
             return new PowerAuthEciesDecryptorParameters(eciesDecryptorResponse.getSecretKey(), eciesDecryptorResponse.getSharedInfo2());
-        } catch (Exception e) {
-            logger.warn("Get Ecies decryptor parameters call failed", e);
+        } catch (Exception ex) {
+            logger.warn("Get ECIES decryptor call failed, error: {}", ex.getMessage());
             throw new PowerAuthEncryptionException();
         }
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/ActivationController.java
@@ -123,11 +123,11 @@ public class ActivationController {
         // Request body needs to be set to null because the SDK uses null for the signature, although {} is sent as request body
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", null, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
         if (!"2.0".equals(apiAuthentication.getVersion()) && !"2.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         return new ObjectResponse<>(activationServiceV3.removeActivation(apiAuthentication));
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/ActivationController.java
@@ -25,6 +25,8 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.v2.ActivationCreateRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.ActivationCreateResponse;
@@ -89,7 +91,8 @@ public class ActivationController {
             logger.warn("Invalid request object in activation create");
             throw new PowerAuthActivationException();
         }
-        return new ObjectResponse<>(activationServiceV2.createActivation(request.getRequestObject()));
+        ActivationCreateResponse response = activationServiceV2.createActivation(request.getRequestObject());
+        return new ObjectResponse<>(response);
     }
 
     /**
@@ -106,7 +109,8 @@ public class ActivationController {
             logger.warn("Invalid request object in activation status");
             throw new PowerAuthActivationException();
         }
-        return new ObjectResponse<>(activationServiceV3.getActivationStatus(request.getRequestObject()));
+        ActivationStatusResponse response = activationServiceV3.getActivationStatus(request.getRequestObject());
+        return new ObjectResponse<>(response);
     }
 
     /**
@@ -123,13 +127,15 @@ public class ActivationController {
         // Request body needs to be set to null because the SDK uses null for the signature, although {} is sent as request body
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", null, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
         if (!"2.0".equals(apiAuthentication.getVersion()) && !"2.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-        return new ObjectResponse<>(activationServiceV3.removeActivation(apiAuthentication));
+        ActivationRemoveResponse response = activationServiceV3.removeActivation(apiAuthentication);
+        return new ObjectResponse<>(response);
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/ActivationController.java
@@ -123,7 +123,7 @@ public class ActivationController {
         // Request body needs to be set to null because the SDK uses null for the signature, although {} is sent as request body
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", null, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException();
         }
         if (!"2.0".equals(apiAuthentication.getVersion()) && !"2.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SecureVaultController.java
@@ -87,12 +87,12 @@ public class SecureVaultController {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         if (!"2.0".equals(header.getVersion()) && !"2.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
 
         return new ObjectResponse<>(secureVaultServiceV2.vaultUnlock(signatureHeader, request.getRequestObject(), httpServletRequest));

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SecureVaultController.java
@@ -86,7 +86,8 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
 
         if (!"2.0".equals(header.getVersion()) && !"2.1".equals(header.getVersion())) {

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SecureVaultController.java
@@ -26,6 +26,8 @@ import io.getlime.security.powerauth.http.validator.InvalidPowerAuthHttpHeaderEx
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.v2.VaultUnlockRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.VaultUnlockResponse;
 import io.getlime.security.powerauth.rest.api.spring.service.v2.SecureVaultService;
@@ -86,16 +88,17 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.warn("Signature HTTP header validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthSignatureInvalidException(ex);
         }
 
         if (!"2.0".equals(header.getVersion()) && !"2.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
 
-        return new ObjectResponse<>(secureVaultServiceV2.vaultUnlock(signatureHeader, request.getRequestObject(), httpServletRequest));
+        VaultUnlockResponse response = secureVaultServiceV2.vaultUnlock(signatureHeader, request.getRequestObject(), httpServletRequest);
+        return new ObjectResponse<>(response);
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SignatureController.java
@@ -69,7 +69,7 @@ public class SignatureController {
             }
             return new Response();
         } else {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException();
         }
 
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SignatureController.java
@@ -65,11 +65,11 @@ public class SignatureController {
         if (auth != null && auth.getActivationId() != null) {
             if (!"2.0".equals(auth.getVersion()) && !"2.1".equals(auth.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new Response();
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/SignatureController.java
@@ -23,6 +23,8 @@ import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,16 +64,15 @@ public class SignatureController {
     })
     public Response validateSignature(PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
 
-        if (auth != null && auth.getActivationId() != null) {
-            if (!"2.0".equals(auth.getVersion()) && !"2.1".equals(auth.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return new Response();
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
-
+        if (!"2.0".equals(auth.getVersion()) && !"2.1".equals(auth.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        return new Response();
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/TokenController.java
@@ -85,16 +85,16 @@ public class TokenController {
             @RequestBody ObjectRequest<TokenCreateRequest> request, PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new ObjectResponse<>(tokenServiceV2.createToken(request.getRequestObject(), authentication));
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 
@@ -115,16 +115,16 @@ public class TokenController {
     public ObjectResponse<TokenRemoveResponse> removeToken(@RequestBody ObjectRequest<TokenRemoveRequest> request, PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v2/TokenController.java
@@ -24,6 +24,8 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.TokenCreateResponse;
@@ -85,17 +87,18 @@ public class TokenController {
             @RequestBody ObjectRequest<TokenCreateRequest> request, PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return new ObjectResponse<>(tokenServiceV2.createToken(request.getRequestObject(), authentication));
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        TokenCreateResponse response = tokenServiceV2.createToken(request.getRequestObject(), authentication);
+        return new ObjectResponse<>(response);
     }
 
     /**
@@ -115,17 +118,18 @@ public class TokenController {
     public ObjectResponse<TokenRemoveResponse> removeToken(@RequestBody ObjectRequest<TokenRemoveRequest> request, PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"2.0".equals(authentication.getVersion()) && !"2.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        TokenRemoveResponse response = tokenServiceV3.removeToken(request.getRequestObject(), authentication);
+        return new ObjectResponse<>(response);
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
@@ -130,7 +130,7 @@ public class ActivationController {
         }
         if (!"3.0".equals(apiAuthentication.getVersion()) && !"3.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         return new ObjectResponse<>(activationServiceV3.removeActivation(apiAuthentication));
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
@@ -126,7 +126,7 @@ public class ActivationController {
         byte[] requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
         PowerAuthApiAuthentication apiAuthentication = authenticationProvider.validateRequestSignature("POST", requestBodyBytes, "/pa/activation/remove", signatureHeader);
         if (apiAuthentication == null || apiAuthentication.getActivationId() == null) {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
         if (!"3.0".equals(apiAuthentication.getVersion()) && !"3.1".equals(apiAuthentication.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", apiAuthentication.getVersion());

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/RecoveryController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/RecoveryController.java
@@ -76,20 +76,20 @@ public class RecoveryController {
                                                       PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         if (request == null) {
             logger.warn("Invalid request object in confirm recovery");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
                 logger.warn("Missing nonce in ECIES request data");
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return recoveryService.confirmRecoveryCode(request, authentication);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/RecoveryController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/RecoveryController.java
@@ -22,6 +22,8 @@ package io.getlime.security.powerauth.rest.api.spring.controller.v3;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
@@ -76,21 +78,20 @@ public class RecoveryController {
                                                       PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         if (request == null) {
             logger.warn("Invalid request object in confirm recovery");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
-                logger.warn("Missing nonce in ECIES request data");
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return recoveryService.confirmRecoveryCode(request, authentication);
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
+            logger.warn("Missing nonce in ECIES request data");
+            throw new PowerAuthInvalidRequestException();
+        }
+        return recoveryService.confirmRecoveryCode(request, authentication);
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
@@ -24,6 +24,8 @@ import io.getlime.security.powerauth.http.validator.InvalidPowerAuthHttpHeaderEx
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.service.v3.SecureVaultService;
@@ -77,7 +79,7 @@ public class SecureVaultController {
 
         if (request == null) {
             logger.warn("Invalid request object in vault unlock");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
 
         // Parse the header
@@ -87,17 +89,17 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.warn("Signature HTTP header validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthSignatureInvalidException(ex);
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
         if (request.getNonce() == null && !"3.0".equals(header.getVersion())) {
             logger.warn("Missing nonce in ECIES request data");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
 
         return secureVaultServiceV3.vaultUnlock(header, request, httpServletRequest);

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
@@ -87,7 +87,8 @@ public class SecureVaultController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SecureVaultController.java
@@ -77,7 +77,7 @@ public class SecureVaultController {
 
         if (request == null) {
             logger.warn("Invalid request object in vault unlock");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
 
         // Parse the header
@@ -88,16 +88,16 @@ public class SecureVaultController {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
             logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         if (request.getNonce() == null && !"3.0".equals(header.getVersion())) {
             logger.warn("Missing nonce in ECIES request data");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
 
         return secureVaultServiceV3.vaultUnlock(header, request, httpServletRequest);

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
@@ -69,7 +69,7 @@ public class SignatureController {
             }
             return new Response();
         } else {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
@@ -23,6 +23,8 @@ import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,16 +64,15 @@ public class SignatureController {
     })
     public Response validateSignature(PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
 
-        if (auth != null && auth.getActivationId() != null) {
-            if (!"3.0".equals(auth.getVersion()) && !"3.1".equals(auth.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return new Response();
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
-
+        if (!"3.0".equals(auth.getVersion()) && !"3.1".equals(auth.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        return new Response();
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
@@ -65,7 +65,7 @@ public class SignatureController {
         if (auth != null && auth.getActivationId() != null) {
             if (!"3.0".equals(auth.getVersion()) && !"3.1".equals(auth.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", auth.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new Response();
         } else {

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
@@ -24,6 +24,8 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
@@ -80,21 +82,21 @@ public class TokenController {
             throws PowerAuthAuthenticationException {
         if (request == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
-                logger.warn("Missing nonce in ECIES request data");
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return tokenServiceV3.createToken(request, authentication);
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
+            logger.warn("Missing nonce in ECIES request data");
+            throw new PowerAuthInvalidRequestException();
+        }
+        return tokenServiceV3.createToken(request, authentication);
     }
 
     /**
@@ -115,17 +117,17 @@ public class TokenController {
                                                            PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in remove token");
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
-        if (authentication != null && authentication.getActivationId() != null) {
-            if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
-                logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
-            }
-            return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (authentication == null || authentication.getActivationId() == null) {
+            throw new PowerAuthSignatureInvalidException();
         }
+        if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
+            logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
+            throw new PowerAuthInvalidRequestException();
+        }
+        TokenRemoveResponse response = tokenServiceV3.removeToken(request.getRequestObject(), authentication);
+        return new ObjectResponse<>(response);
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/TokenController.java
@@ -80,20 +80,20 @@ public class TokenController {
             throws PowerAuthAuthenticationException {
         if (request == null) {
             logger.warn("Invalid request object in create token");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             if (request.getNonce() == null && !"3.0".equals(authentication.getVersion())) {
                 logger.warn("Missing nonce in ECIES request data");
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return tokenServiceV3.createToken(request, authentication);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 
@@ -115,16 +115,16 @@ public class TokenController {
                                                            PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
         if (request.getRequestObject() == null) {
             logger.warn("Invalid request object in remove token");
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
         if (authentication != null && authentication.getActivationId() != null) {
             if (!"3.0".equals(authentication.getVersion()) && !"3.1".equals(authentication.getVersion())) {
                 logger.warn("Endpoint does not support PowerAuth protocol version {}", authentication.getVersion());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new ObjectResponse<>(tokenServiceV3.removeToken(request.getRequestObject(), authentication));
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
@@ -85,7 +85,7 @@ public class UpgradeController {
         try {
             PowerAuthEncryptionHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            logger.warn("Encryption validation failed, error: {}", ex.getMessage());
             throw new PowerAuthUpgradeException();
         }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
@@ -130,7 +130,7 @@ public class UpgradeController {
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
         }
 
         return upgradeService.upgradeCommit(signatureHeader, httpServletRequest);

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
@@ -27,6 +27,7 @@ import io.getlime.security.powerauth.http.validator.PowerAuthEncryptionHttpHeade
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthUpgradeException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.service.v3.UpgradeService;
@@ -86,7 +87,7 @@ public class UpgradeController {
             PowerAuthEncryptionHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
             logger.warn("Encryption validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthUpgradeException();
+            throw new PowerAuthUpgradeException(ex);
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
@@ -124,13 +125,13 @@ public class UpgradeController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            logger.warn("Signature validation failed, error: {}", ex.getMessage());
-            throw new PowerAuthUpgradeException();
+            logger.warn("Signature HTTP header validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthUpgradeException(ex);
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
             logger.warn("Endpoint does not support PowerAuth protocol version {}", header.getVersion());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+            throw new PowerAuthInvalidRequestException();
         }
 
         return upgradeService.upgradeCommit(signatureHeader, httpServletRequest);

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/v3/UpgradeController.java
@@ -85,7 +85,8 @@ public class UpgradeController {
         try {
             PowerAuthEncryptionHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            throw new PowerAuthUpgradeException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthUpgradeException();
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {
@@ -123,7 +124,8 @@ public class UpgradeController {
         try {
             PowerAuthSignatureHttpHeaderValidator.validate(header);
         } catch (InvalidPowerAuthHttpHeaderException ex) {
-            throw new PowerAuthUpgradeException(ex.getMessage());
+            logger.warn("Signature validation failed, error: {}", ex.getMessage());
+            throw new PowerAuthUpgradeException();
         }
 
         if (!"3.0".equals(header.getVersion()) && !"3.1".equals(header.getVersion())) {

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/exception/PowerAuthExceptionHandler.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/exception/PowerAuthExceptionHandler.java
@@ -54,7 +54,7 @@ public class PowerAuthExceptionHandler {
     @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
     public @ResponseBody ErrorResponse handleUnauthorizedException(Exception ex) {
         PowerAuthAuthenticationException paex = (PowerAuthAuthenticationException)ex;
-        logger.error(paex.getMessage(), paex);
+        logger.warn(paex.getMessage(), paex);
         return new ErrorResponse(paex.getDefaultCode(), paex);
     }
 
@@ -67,7 +67,7 @@ public class PowerAuthExceptionHandler {
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleActivationException(Exception ex) {
         PowerAuthActivationException paex = (PowerAuthActivationException)ex;
-        logger.error(paex.getMessage(), paex);
+        logger.warn(paex.getMessage(), paex);
         return new ErrorResponse(paex.getDefaultCode(), paex);
     }
 
@@ -81,7 +81,7 @@ public class PowerAuthExceptionHandler {
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public @ResponseBody RecoveryErrorResponse handleRecoveryException(Exception ex) {
         PowerAuthRecoveryException paex = (PowerAuthRecoveryException)ex;
-        logger.error(paex.getMessage(), paex);
+        logger.warn(paex.getMessage(), paex);
         return new RecoveryErrorResponse(paex.getErrorCode(), paex, paex.getCurrentRecoveryPukIndex());
     }
 
@@ -94,7 +94,7 @@ public class PowerAuthExceptionHandler {
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleSecureVaultException(Exception ex) {
         PowerAuthSecureVaultException paex = (PowerAuthSecureVaultException)ex;
-        logger.error(paex.getMessage(), paex);
+        logger.warn(paex.getMessage(), paex);
         return new ErrorResponse(paex.getDefaultCode(), paex);
     }
 
@@ -107,7 +107,7 @@ public class PowerAuthExceptionHandler {
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handlePowerAuthEncryptionException(Exception ex) {
         PowerAuthEncryptionException paex = (PowerAuthEncryptionException)ex;
-        logger.error(paex.getMessage(), paex);
+        logger.warn(paex.getMessage(), paex);
         return new ErrorResponse(paex.getDefaultCode(), paex);
     }
 
@@ -120,7 +120,7 @@ public class PowerAuthExceptionHandler {
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handlePowerAuthUpgradeException(Exception ex) {
         PowerAuthUpgradeException pamx = (PowerAuthUpgradeException)ex;
-        logger.error(pamx.getMessage(), pamx);
+        logger.warn(pamx.getMessage(), pamx);
         return new ErrorResponse(pamx.getDefaultCode(), pamx);
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/ActivationService.java
@@ -90,7 +90,7 @@ public class ActivationService {
 
             return response;
         } catch (Exception ex) {
-            logger.warn("Creating PowerAuth activation failed", ex);
+            logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/ActivationService.java
@@ -91,7 +91,7 @@ public class ActivationService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/SecureVaultService.java
@@ -28,6 +28,8 @@ import io.getlime.security.powerauth.http.validator.InvalidPowerAuthHttpHeaderEx
 import io.getlime.security.powerauth.http.validator.PowerAuthSignatureHttpHeaderValidator;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthSecureVaultException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureTypeInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.v2.VaultUnlockRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.VaultUnlockResponse;
 import io.getlime.security.powerauth.rest.api.spring.converter.v2.SignatureTypeConverter;
@@ -90,8 +92,8 @@ public class SecureVaultService {
             try {
                 PowerAuthSignatureHttpHeaderValidator.validate(header);
             } catch (InvalidPowerAuthHttpHeaderException ex) {
-                logger.warn("Signature validation failed, error: {}", ex.getMessage());
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+                logger.warn("Signature HTTP header validation failed, error: {}", ex.getMessage());
+                throw new PowerAuthSignatureTypeInvalidException(ex);
             }
 
             SignatureTypeConverter converter = new SignatureTypeConverter();
@@ -101,7 +103,8 @@ public class SecureVaultService {
             String signature = header.getSignature();
             SignatureType signatureType = converter.convertFrom(header.getSignatureType());
             if (signatureType == null) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+                logger.warn("Invalid signature type: {}", header.getSignatureType());
+                throw new PowerAuthSignatureTypeInvalidException();
             }
             String nonce = header.getNonce();
 
@@ -123,6 +126,7 @@ public class SecureVaultService {
                 // Use POST request body as data for signature.
                 requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
             } else {
+                logger.warn("Invalid protocol version in secure vault: {}", header.getVersion());
                 throw new PowerAuthSecureVaultException();
             }
 
@@ -131,7 +135,8 @@ public class SecureVaultService {
             com.wultra.security.powerauth.client.v2.VaultUnlockResponse paResponse = powerAuthClient.v2().unlockVault(activationId, applicationId, data, signature, signatureType, reason);
 
             if (!paResponse.isSignatureValid()) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+                logger.debug("Signature validation failed");
+                throw new PowerAuthSignatureInvalidException();
             }
 
             VaultUnlockResponse response = new VaultUnlockResponse();
@@ -143,7 +148,7 @@ public class SecureVaultService {
             throw ex;
         } catch (Exception ex) {
             logger.warn("PowerAuth vault unlock failed, error: {}", ex.getMessage());
-            throw new PowerAuthSecureVaultException();
+            throw new PowerAuthSecureVaultException(ex);
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/SecureVaultService.java
@@ -89,8 +89,9 @@ public class SecureVaultService {
             // Validate the header
             try {
                 PowerAuthSignatureHttpHeaderValidator.validate(header);
-            } catch (InvalidPowerAuthHttpHeaderException e) {
-                throw new PowerAuthAuthenticationException(e.getMessage());
+            } catch (InvalidPowerAuthHttpHeaderException ex) {
+                logger.warn("Signature validation failed, error: {}", ex.getMessage());
+                throw new PowerAuthAuthenticationException();
             }
 
             SignatureTypeConverter converter = new SignatureTypeConverter();
@@ -99,6 +100,9 @@ public class SecureVaultService {
             String applicationId = header.getApplicationKey();
             String signature = header.getSignature();
             SignatureType signatureType = converter.convertFrom(header.getSignatureType());
+            if (signatureType == null) {
+                throw new PowerAuthAuthenticationException();
+            }
             String nonce = header.getNonce();
 
             String reason = null;
@@ -138,7 +142,7 @@ public class SecureVaultService {
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
-            logger.warn("PowerAuth vault unlock failed", ex);
+            logger.warn("PowerAuth vault unlock failed, error: {}", ex.getMessage());
             throw new PowerAuthSecureVaultException();
         }
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/SecureVaultService.java
@@ -91,7 +91,7 @@ public class SecureVaultService {
                 PowerAuthSignatureHttpHeaderValidator.validate(header);
             } catch (InvalidPowerAuthHttpHeaderException ex) {
                 logger.warn("Signature validation failed, error: {}", ex.getMessage());
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
 
             SignatureTypeConverter converter = new SignatureTypeConverter();
@@ -101,7 +101,7 @@ public class SecureVaultService {
             String signature = header.getSignature();
             SignatureType signatureType = converter.convertFrom(header.getSignatureType());
             if (signatureType == null) {
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
             }
             String nonce = header.getNonce();
 
@@ -131,7 +131,7 @@ public class SecureVaultService {
             com.wultra.security.powerauth.client.v2.VaultUnlockResponse paResponse = powerAuthClient.v2().unlockVault(activationId, applicationId, data, signature, signatureType, reason);
 
             if (!paResponse.isSignatureValid()) {
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
 
             VaultUnlockResponse response = new VaultUnlockResponse();

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/TokenService.java
@@ -84,8 +84,8 @@ public class TokenService {
             response.setEncryptedData(token.getEncryptedData());
             return response;
         } catch (Exception ex) {
-            logger.warn("Creating PowerAuth token failed", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/TokenService.java
@@ -24,6 +24,7 @@ import com.wultra.security.powerauth.client.v2.CreateTokenResponse;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthTokenErrorException;
 import io.getlime.security.powerauth.rest.api.model.request.v2.TokenCreateRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v2.TokenCreateResponse;
 import io.getlime.security.powerauth.rest.api.spring.converter.v2.SignatureTypeConverter;
@@ -85,7 +86,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
+            throw new PowerAuthTokenErrorException(ex);
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v2/TokenService.java
@@ -85,7 +85,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
@@ -265,22 +265,22 @@ public class ActivationService {
                 }
 
                 default:
-                    throw new PowerAuthAuthenticationException("Unsupported activation type: " + request.getType());
+                    throw new PowerAuthAuthenticationException();
             }
         } catch (PowerAuthClientException ex) {
             if (ex.getPowerAuthError() instanceof PowerAuthErrorRecovery) {
                 PowerAuthErrorRecovery errorRecovery = (PowerAuthErrorRecovery) ex.getPowerAuthError();
                 throw new PowerAuthRecoveryException(ex.getMessage(), "INVALID_RECOVERY_CODE", errorRecovery.getCurrentRecoveryPukIndex());
             }
-            logger.warn("Creating PowerAuth activation failed", ex);
+            logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         } catch (PowerAuthActivationException ex) {
             // Do not swallow PowerAuthActivationException for custom activations.
             // See: https://github.com/wultra/powerauth-restful-integration/issues/199
-            logger.warn("Creating PowerAuth activation failed", ex);
+            logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
             throw ex;
         } catch (Exception ex) {
-            logger.warn("Creating PowerAuth activation failed", ex);
+            logger.warn("Creating PowerAuth activation failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }
@@ -306,7 +306,7 @@ public class ActivationService {
             }
             return response;
         } catch (Exception ex) {
-            logger.warn("PowerAuth activation status check failed", ex);
+            logger.warn("PowerAuth activation status check failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }
@@ -341,7 +341,7 @@ public class ActivationService {
             response.setActivationId(paResponse.getActivationId());
             return response;
         } catch (Exception ex) {
-            logger.warn("PowerAuth activation removal failed", ex);
+            logger.warn("PowerAuth activation removal failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/ActivationService.java
@@ -265,7 +265,7 @@ public class ActivationService {
                 }
 
                 default:
-                    throw new PowerAuthAuthenticationException();
+                    throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
         } catch (PowerAuthClientException ex) {
             if (ex.getPowerAuthError() instanceof PowerAuthErrorRecovery) {

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/RecoveryService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/RecoveryService.java
@@ -72,18 +72,18 @@ public class RecoveryService {
             final String applicationKey = httpHeader.getApplicationKey();
             if (activationId == null || applicationKey == null || request.getEphemeralPublicKey() == null
                     || request.getEncryptedData() == null || request.getMac() == null) {
-                logger.error("PowerAuth confirm recovery failed because of invalid request");
+                logger.warn("PowerAuth confirm recovery failed because of invalid request");
                 throw new PowerAuthAuthenticationException();
             }
             ConfirmRecoveryCodeResponse paResponse = powerAuthClient.confirmRecoveryCode(activationId, applicationKey,
                     request.getEphemeralPublicKey(), request.getEncryptedData(), request.getMac(), request.getNonce());
             if (!paResponse.getActivationId().equals(activationId)) {
-                logger.error("PowerAuth confirm recovery failed because of invalid activation ID in response");
+                logger.warn("PowerAuth confirm recovery failed because of invalid activation ID in response");
                 throw new PowerAuthAuthenticationException();
             }
             return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac());
         } catch (Exception ex) {
-            logger.warn("PowerAuth confirm recovery failed", ex);
+            logger.warn("PowerAuth confirm recovery failed, error: {}", ex.getMessage());
             throw new PowerAuthAuthenticationException();
         }
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/RecoveryService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/RecoveryService.java
@@ -73,18 +73,18 @@ public class RecoveryService {
             if (activationId == null || applicationKey == null || request.getEphemeralPublicKey() == null
                     || request.getEncryptedData() == null || request.getMac() == null) {
                 logger.warn("PowerAuth confirm recovery failed because of invalid request");
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             ConfirmRecoveryCodeResponse paResponse = powerAuthClient.confirmRecoveryCode(activationId, applicationKey,
                     request.getEphemeralPublicKey(), request.getEncryptedData(), request.getMac(), request.getNonce());
             if (!paResponse.getActivationId().equals(activationId)) {
                 logger.warn("PowerAuth confirm recovery failed because of invalid activation ID in response");
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
             return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac());
         } catch (Exception ex) {
             logger.warn("PowerAuth confirm recovery failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_RECOVERY_ERROR");
         }
     }
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/RecoveryService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/RecoveryService.java
@@ -24,6 +24,8 @@ import com.wultra.security.powerauth.client.v3.ConfirmRecoveryCodeResponse;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthRecoveryConfirmationException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import org.slf4j.Logger;
@@ -73,18 +75,18 @@ public class RecoveryService {
             if (activationId == null || applicationKey == null || request.getEphemeralPublicKey() == null
                     || request.getEncryptedData() == null || request.getMac() == null) {
                 logger.warn("PowerAuth confirm recovery failed because of invalid request");
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+                throw new PowerAuthInvalidRequestException();
             }
             ConfirmRecoveryCodeResponse paResponse = powerAuthClient.confirmRecoveryCode(activationId, applicationKey,
                     request.getEphemeralPublicKey(), request.getEncryptedData(), request.getMac(), request.getNonce());
             if (!paResponse.getActivationId().equals(activationId)) {
                 logger.warn("PowerAuth confirm recovery failed because of invalid activation ID in response");
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+                throw new PowerAuthInvalidRequestException();
             }
             return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac());
         } catch (Exception ex) {
             logger.warn("PowerAuth confirm recovery failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_RECOVERY_ERROR");
+            throw new PowerAuthRecoveryConfirmationException(ex);
         }
     }
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/SecureVaultService.java
@@ -88,7 +88,7 @@ public class SecureVaultService {
             String signature = header.getSignature();
             SignatureType signatureType = converter.convertFrom(header.getSignatureType());
             if (signatureType == null) {
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
             }
             String signatureVersion = header.getVersion();
             String nonce = header.getNonce();
@@ -108,7 +108,7 @@ public class SecureVaultService {
                     signatureType, signatureVersion, data, ephemeralPublicKey, encryptedData, mac, eciesNonce);
 
             if (!paResponse.isSignatureValid()) {
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
 
             return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac());

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/SecureVaultService.java
@@ -87,6 +87,9 @@ public class SecureVaultService {
             String applicationKey = header.getApplicationKey();
             String signature = header.getSignature();
             SignatureType signatureType = converter.convertFrom(header.getSignatureType());
+            if (signatureType == null) {
+                throw new PowerAuthAuthenticationException();
+            }
             String signatureVersion = header.getVersion();
             String nonce = header.getNonce();
 
@@ -112,7 +115,7 @@ public class SecureVaultService {
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
-            logger.warn("PowerAuth vault unlock failed", ex);
+            logger.warn("PowerAuth vault unlock failed, error: {}", ex.getMessage());
             throw new PowerAuthSecureVaultException();
         }
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
@@ -21,6 +21,7 @@ package io.getlime.security.powerauth.rest.api.spring.service.v3;
 
 import com.wultra.security.powerauth.client.PowerAuthClient;
 import com.wultra.security.powerauth.client.v3.CreateTokenResponse;
+import com.wultra.security.powerauth.client.v3.SignatureType;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
@@ -80,6 +81,10 @@ public class TokenService {
 
             // Prepare a signature type converter
             SignatureTypeConverter converter = new SignatureTypeConverter();
+            SignatureType signatureType = converter.convertFrom(signatureFactors);
+            if (signatureType == null) {
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+            }
 
             // Get ECIES headers
             String activationId = authentication.getActivationId();
@@ -88,7 +93,7 @@ public class TokenService {
 
             // Create a token
             final CreateTokenResponse token = powerAuthClient.createToken(activationId, applicationKey, ephemeralPublicKey,
-                    encryptedData, mac, nonce, converter.convertFrom(signatureFactors));
+                    encryptedData, mac, nonce, signatureType);
 
             // Prepare a response
             final EciesEncryptedResponse response = new EciesEncryptedResponse();

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
@@ -102,7 +102,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
         }
     }
 
@@ -131,7 +131,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Removing PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
         }
     }
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
@@ -26,6 +26,8 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureTypeInvalidException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthTokenErrorException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.request.v3.TokenRemoveRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
@@ -83,7 +85,8 @@ public class TokenService {
             SignatureTypeConverter converter = new SignatureTypeConverter();
             SignatureType signatureType = converter.convertFrom(signatureFactors);
             if (signatureType == null) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_TYPE_INVALID");
+                logger.warn("Invalid signature type: {}", signatureFactors);
+                throw new PowerAuthSignatureTypeInvalidException();
             }
 
             // Get ECIES headers
@@ -102,7 +105,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
+            throw new PowerAuthTokenErrorException(ex);
         }
     }
 
@@ -131,7 +134,7 @@ public class TokenService {
             return response;
         } catch (Exception ex) {
             logger.warn("Removing PowerAuth token failed, error: {}", ex.getMessage());
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_ERROR");
+            throw new PowerAuthTokenErrorException(ex);
         }
     }
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/TokenService.java
@@ -96,8 +96,8 @@ public class TokenService {
             response.setEncryptedData(token.getEncryptedData());
             return response;
         } catch (Exception ex) {
-            logger.warn("Creating PowerAuth token failed", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Creating PowerAuth token failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
     }
 
@@ -125,8 +125,8 @@ public class TokenService {
             response.setTokenId(tokenId);
             return response;
         } catch (Exception ex) {
-            logger.warn("Removing PowerAuth token failed", ex);
-            throw new PowerAuthAuthenticationException(ex.getMessage());
+            logger.warn("Removing PowerAuth token failed, error: {}", ex.getMessage());
+            throw new PowerAuthAuthenticationException();
         }
     }
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
@@ -100,7 +100,7 @@ public class UpgradeService {
             response.setEncryptedData(upgradeResponse.getEncryptedData());
             return response;
         } catch (Exception ex) {
-            logger.warn("PowerAuth upgrade start failed", ex);
+            logger.warn("PowerAuth upgrade start failed, error: {}", ex.getMessage());
             throw new PowerAuthUpgradeException();
         }
     }
@@ -150,7 +150,7 @@ public class UpgradeService {
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
-            logger.warn("PowerAuth upgrade commit failed", ex);
+            logger.warn("PowerAuth upgrade commit failed, error: {}", ex.getMessage());
             throw new PowerAuthUpgradeException();
         }
     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
@@ -122,7 +122,7 @@ public class UpgradeService {
             byte[] requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
             if (requestBodyBytes == null || requestBodyBytes.length == 0) {
                 // Expected request body is {}, do not accept empty body
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
             }
 
             // Verify signature, force signature version during upgrade to version 3

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
@@ -29,6 +29,8 @@ import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthUpgradeException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthInvalidRequestException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.v3.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
@@ -101,7 +103,7 @@ public class UpgradeService {
             return response;
         } catch (Exception ex) {
             logger.warn("PowerAuth upgrade start failed, error: {}", ex.getMessage());
-            throw new PowerAuthUpgradeException();
+            throw new PowerAuthUpgradeException(ex);
         }
     }
 
@@ -122,7 +124,8 @@ public class UpgradeService {
             byte[] requestBodyBytes = authenticationProvider.extractRequestBodyBytes(httpServletRequest);
             if (requestBodyBytes == null || requestBodyBytes.length == 0) {
                 // Expected request body is {}, do not accept empty body
-                throw new PowerAuthAuthenticationException("POWER_AUTH_REQUEST_INVALID");
+                logger.warn("Empty request body");
+                throw new PowerAuthInvalidRequestException();
             }
 
             // Verify signature, force signature version during upgrade to version 3
@@ -131,7 +134,8 @@ public class UpgradeService {
 
             // In case signature verification fails, upgrade fails, too
             if (authentication == null || authentication.getActivationId() == null) {
-                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+                logger.debug("Signature validation failed");
+                throw new PowerAuthSignatureInvalidException();
             }
 
             // Get signature HTTP headers
@@ -145,13 +149,14 @@ public class UpgradeService {
             if (upgradeResponse.isCommitted()) {
                 return new Response();
             } else {
+                logger.debug("Upgrade commit failed");
                 throw new PowerAuthUpgradeException();
             }
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {
             logger.warn("PowerAuth upgrade commit failed, error: {}", ex.getMessage());
-            throw new PowerAuthUpgradeException();
+            throw new PowerAuthUpgradeException(ex);
         }
     }
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/v3/UpgradeService.java
@@ -131,7 +131,7 @@ public class UpgradeService {
 
             // In case signature verification fails, upgrade fails, too
             if (authentication == null || authentication.getActivationId() == null) {
-                throw new PowerAuthAuthenticationException();
+                throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
             }
 
             // Get signature HTTP headers

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/configuration/PowerAuthBeanFactory.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/configuration/PowerAuthBeanFactory.java
@@ -23,6 +23,8 @@ import io.getlime.security.powerauth.rest.api.base.application.PowerAuthApplicat
 import io.getlime.security.powerauth.rest.api.jaxrs.application.DefaultApplicationConfiguration;
 import io.getlime.security.powerauth.soap.axis.client.PowerAuthServiceClient;
 import org.apache.axis2.AxisFault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
@@ -35,11 +37,14 @@ import javax.enterprise.inject.Produces;
 @Dependent
 public class PowerAuthBeanFactory {
 
+    private static final Logger logger = LoggerFactory.getLogger(PowerAuthBeanFactory.class);
+
     @Produces
     public PowerAuthServiceClient buildClient() {
         try {
             return new PowerAuthServiceClient("http://localhost:8080/powerauth-java-server/soap");
-        } catch (AxisFault axisFault) {
+        } catch (AxisFault ex) {
+            logger.warn("Failes to build client, error: {}", ex.getMessage());
             return null;
         }
     }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/configuration/PowerAuthBeanFactory.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/configuration/PowerAuthBeanFactory.java
@@ -45,6 +45,7 @@ public class PowerAuthBeanFactory {
             return new PowerAuthServiceClient("http://localhost:8080/powerauth-java-server/soap");
         } catch (AxisFault ex) {
             logger.warn("Failed to build client, error: {}", ex.getMessage());
+            logger.debug("Error details", ex);
             return null;
         }
     }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/configuration/PowerAuthBeanFactory.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/configuration/PowerAuthBeanFactory.java
@@ -44,7 +44,7 @@ public class PowerAuthBeanFactory {
         try {
             return new PowerAuthServiceClient("http://localhost:8080/powerauth-java-server/soap");
         } catch (AxisFault ex) {
-            logger.warn("Failes to build client, error: {}", ex.getMessage());
+            logger.warn("Failed to build client, error: {}", ex.getMessage());
             return null;
         }
     }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/AuthenticationController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/AuthenticationController.java
@@ -71,7 +71,7 @@ public class AuthenticationController {
                     + " using factor: " + auth.getSignatureFactors()
             );
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
     }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/AuthenticationController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/AuthenticationController.java
@@ -71,7 +71,7 @@ public class AuthenticationController {
                     + " using factor: " + auth.getSignatureFactors()
             );
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed.");
+            throw new PowerAuthAuthenticationException();
         }
 
     }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/AuthenticationController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/AuthenticationController.java
@@ -23,6 +23,7 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 
 import javax.inject.Inject;
@@ -63,17 +64,15 @@ public class AuthenticationController {
                 authHeader
         );
 
-        if (auth != null && auth.getUserId() != null) {
-            return new ObjectResponse<>("Hooray! "
-                    + " User: " + auth.getUserId()
-                    + " (activation: " + auth.getActivationId() + ")"
-                    + " successfully verified via app with ID: " + auth.getApplicationId()
-                    + " using factor: " + auth.getSignatureFactors()
-            );
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getUserId() == null) {
+            throw new PowerAuthSignatureInvalidException();
         }
-
+        return new ObjectResponse<>("Hooray! "
+                + " User: " + auth.getUserId()
+                + " (activation: " + auth.getActivationId() + ")"
+                + " successfully verified via app with ID: " + auth.getApplicationId()
+                + " using factor: " + auth.getSignatureFactors()
+        );
     }
 
 }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/TokenController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/TokenController.java
@@ -23,6 +23,7 @@ import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.http.PowerAuthTokenHttpHeader;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthTokenInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 
 import javax.inject.Inject;
@@ -47,11 +48,10 @@ public class TokenController {
     @Produces(MediaType.APPLICATION_JSON)
     public Response authorize(@HeaderParam(value = PowerAuthTokenHttpHeader.HEADER_NAME) String tokenHeader) throws PowerAuthAuthenticationException {
         PowerAuthApiAuthentication auth = authenticationProvider.validateToken(tokenHeader);
-        if (auth != null && auth.getUserId() != null) {
-            return new Response();
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_INVALID");
+        if (auth == null || auth.getUserId() == null) {
+            throw new PowerAuthTokenInvalidException();
         }
+        return new Response();
     }
 
 }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/TokenController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/TokenController.java
@@ -50,7 +50,7 @@ public class TokenController {
         if (auth != null && auth.getUserId() != null) {
             return new Response();
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed.");
+            throw new PowerAuthAuthenticationException();
         }
     }
 

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/TokenController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/TokenController.java
@@ -50,7 +50,7 @@ public class TokenController {
         if (auth != null && auth.getUserId() != null) {
             return new Response();
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_TOKEN_INVALID");
         }
     }
 

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v2/CustomActivationController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v2/CustomActivationController.java
@@ -86,19 +86,23 @@ public class CustomActivationController {
             final PowerAuthNonPersonalizedEncryptor encryptor = encryptorFactory.buildNonPersonalizedEncryptor(object);
 
             if (encryptor == null) {
+                logger.warn("Activation provider is missing");
                 throw new PowerAuthActivationException();
             }
 
             ActivationCreateCustomRequest request = encryptor.decrypt(object, ActivationCreateCustomRequest.class);
 
             if (request == null) {
+                logger.warn("Encryptor is not available");
                 throw new PowerAuthActivationException();
             }
 
             final Map<String, String> identity = request.getIdentity();
             String userId = activationProvider.lookupUserIdForAttributes(identity);
 
-            if (userId == null) {
+            // If no user was found or user ID is invalid, return error
+            if (userId == null || userId.equals("") || userId.length() > 255) {
+                logger.warn("User ID is invalid: {}", userId);
                 throw new PowerAuthActivationException();
             }
 
@@ -135,7 +139,7 @@ public class CustomActivationController {
 
         } catch (Exception ex) {
             logger.warn("Create activation failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
 
     }

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v2/CustomActivationController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v2/CustomActivationController.java
@@ -22,8 +22,6 @@ package io.getlime.security.powerauth.app.rest.api.javaee.controller.v2;
 import com.wultra.security.powerauth.client.v2.PowerAuthPortV2ServiceStub;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
-import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
-import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthNonPersonalizedEncryptor;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthActivationException;
 import io.getlime.security.powerauth.rest.api.base.provider.CustomActivationProvider;
@@ -43,8 +41,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
-import java.security.InvalidKeyException;
 import java.util.Map;
 
 /**
@@ -138,7 +134,7 @@ public class CustomActivationController {
             return powerAuthApiResponse;
 
         } catch (Exception ex) {
-            logger.warn(ex.getMessage(), ex);
+            logger.warn("Create activation failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
 

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v2/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v2/EncryptedDataExchangeController.java
@@ -76,6 +76,7 @@ public class EncryptedDataExchangeController {
     @Produces(MediaType.APPLICATION_JSON)
     public ObjectResponse<NonPersonalizedEncryptedPayloadModel> exchange(ObjectRequest<NonPersonalizedEncryptedPayloadModel> request) throws PowerAuthEncryptionException {
         if (request == null) {
+            logger.warn("Invalid request in exchange method");
             throw new PowerAuthEncryptionException();
         }
 
@@ -85,7 +86,7 @@ public class EncryptedDataExchangeController {
              encryptor = encryptorFactory.buildNonPersonalizedEncryptor(request);
         } catch (RemoteException ex) {
             logger.warn("Remote communication failed, error: {}", ex.getMessage());
-            throw new PowerAuthEncryptionException();
+            throw new PowerAuthEncryptionException(ex);
         }
 
         // Decrypt the request object
@@ -94,10 +95,11 @@ public class EncryptedDataExchangeController {
             requestDataBytes = encryptor.decrypt(request);
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
             logger.warn("Encryption failed, error: {}", ex.getMessage());
-            throw new PowerAuthEncryptionException();
+            throw new PowerAuthEncryptionException(ex);
         }
 
         if (requestDataBytes == null) {
+            logger.warn("Invalid request data in exchange method");
             throw new PowerAuthEncryptionException();
         }
 
@@ -112,7 +114,7 @@ public class EncryptedDataExchangeController {
             encryptedResponse = encryptor.encrypt(responseData.getBytes());
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
             logger.warn("Encryption failed, error: {}", ex.getMessage());
-            throw new PowerAuthEncryptionException();
+            throw new PowerAuthEncryptionException(ex);
         }
 
         return encryptedResponse;

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v2/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v2/EncryptedDataExchangeController.java
@@ -84,6 +84,7 @@ public class EncryptedDataExchangeController {
         try {
              encryptor = encryptorFactory.buildNonPersonalizedEncryptor(request);
         } catch (RemoteException ex) {
+            logger.warn("Remote communication failed, error: {}", ex.getMessage());
             throw new PowerAuthEncryptionException();
         }
 
@@ -92,7 +93,7 @@ public class EncryptedDataExchangeController {
         try {
             requestDataBytes = encryptor.decrypt(request);
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
-            logger.warn(ex.getMessage(), ex);
+            logger.warn("Encryption failed, error: {}", ex.getMessage());
             throw new PowerAuthEncryptionException();
         }
 
@@ -110,7 +111,7 @@ public class EncryptedDataExchangeController {
         try {
             encryptedResponse = encryptor.encrypt(responseData.getBytes());
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
-            logger.warn(ex.getMessage(), ex);
+            logger.warn("Encryption failed, error: {}", ex.getMessage());
             throw new PowerAuthEncryptionException();
         }
 

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v3/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v3/EncryptedDataExchangeController.java
@@ -79,7 +79,7 @@ public class EncryptedDataExchangeController {
         EciesEncryptionContext eciesContext = eciesEncryption.getContext();
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Prepare response object
@@ -108,7 +108,7 @@ public class EncryptedDataExchangeController {
         EciesEncryptionContext eciesContext = eciesEncryption.getContext();
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Prepare response object
@@ -137,7 +137,7 @@ public class EncryptedDataExchangeController {
         DataExchangeRequest request = eciesEncryption.getRequestObject();
 
         if (eciesEncryption.getContext() == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Verify PowerAuth signature
@@ -154,7 +154,7 @@ public class EncryptedDataExchangeController {
             // Encrypt response
             return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 
@@ -177,7 +177,7 @@ public class EncryptedDataExchangeController {
         String requestData = eciesEncryption.getRequestObject();
 
         if (eciesEncryption.getContext() == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Verify PowerAuth signature
@@ -194,7 +194,7 @@ public class EncryptedDataExchangeController {
             // Encrypt response
             return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 
@@ -217,7 +217,7 @@ public class EncryptedDataExchangeController {
         byte[] requestData = eciesEncryption.getRequestObject();
 
         if (eciesEncryption.getContext() == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Verify PowerAuth signature
@@ -231,7 +231,7 @@ public class EncryptedDataExchangeController {
             // Encrypt response - return the same data as in request
             return encryptionProvider.encryptResponse(requestData, eciesEncryption);
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
     }
 

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v3/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v3/EncryptedDataExchangeController.java
@@ -154,7 +154,7 @@ public class EncryptedDataExchangeController {
             // Encrypt response
             return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed.");
+            throw new PowerAuthAuthenticationException();
         }
     }
 
@@ -194,7 +194,7 @@ public class EncryptedDataExchangeController {
             // Encrypt response
             return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed.");
+            throw new PowerAuthAuthenticationException();
         }
     }
 
@@ -231,7 +231,7 @@ public class EncryptedDataExchangeController {
             // Encrypt response - return the same data as in request
             return encryptionProvider.encryptResponse(requestData, eciesEncryption);
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed.");
+            throw new PowerAuthAuthenticationException();
         }
     }
 

--- a/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v3/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-javaee/src/main/java/io/getlime/security/powerauth/app/rest/api/javaee/controller/v3/EncryptedDataExchangeController.java
@@ -28,9 +28,12 @@ import io.getlime.security.powerauth.rest.api.base.encryption.EciesEncryptionCon
 import io.getlime.security.powerauth.rest.api.base.encryption.PowerAuthEciesEncryption;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthEncryptionException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthAuthenticationProvider;
 import io.getlime.security.powerauth.rest.api.jaxrs.provider.PowerAuthEncryptionProvider;
 import io.getlime.security.powerauth.rest.api.model.response.v3.EciesEncryptedResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -51,6 +54,8 @@ import javax.ws.rs.core.MediaType;
 @Path("/exchange")
 @Produces(MediaType.APPLICATION_JSON)
 public class EncryptedDataExchangeController {
+
+    private static final Logger logger = LoggerFactory.getLogger(EncryptedDataExchangeController.class);
 
     @Inject
     private PowerAuthEncryptionProvider encryptionProvider;
@@ -79,6 +84,7 @@ public class EncryptedDataExchangeController {
         EciesEncryptionContext eciesContext = eciesEncryption.getContext();
 
         if (eciesContext == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -108,6 +114,7 @@ public class EncryptedDataExchangeController {
         EciesEncryptionContext eciesContext = eciesEncryption.getContext();
 
         if (eciesContext == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -137,6 +144,7 @@ public class EncryptedDataExchangeController {
         DataExchangeRequest request = eciesEncryption.getRequestObject();
 
         if (eciesEncryption.getContext() == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -147,15 +155,15 @@ public class EncryptedDataExchangeController {
                 authHeader
         );
 
-        if (auth != null && auth.getUserId() != null) {
-            // Prepare response object
-            DataExchangeResponse exchangeResponse = new DataExchangeResponse("Server successfully decrypted data and verified signature, request data: " + (request == null ? "''" : request.getData()) + ", user ID: " + auth.getUserId());
-
-            // Encrypt response
-            return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getUserId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        // Prepare response object
+        DataExchangeResponse exchangeResponse = new DataExchangeResponse("Server successfully decrypted data and verified signature, request data: " + (request == null ? "''" : request.getData()) + ", user ID: " + auth.getUserId());
+
+        // Encrypt response
+        return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
     }
 
     /**
@@ -177,6 +185,7 @@ public class EncryptedDataExchangeController {
         String requestData = eciesEncryption.getRequestObject();
 
         if (eciesEncryption.getContext() == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -187,15 +196,15 @@ public class EncryptedDataExchangeController {
                 authHeader
         );
 
-        if (auth != null && auth.getUserId() != null) {
-            // Prepare response String
-            String exchangeResponse = "Server successfully decrypted data and verified signature, request data: " + (requestData == null ? "''" : requestData) + ", user ID: " + auth.getUserId();
-
-            // Encrypt response
-            return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getUserId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        // Prepare response String
+        String exchangeResponse = "Server successfully decrypted data and verified signature, request data: " + (requestData == null ? "''" : requestData) + ", user ID: " + auth.getUserId();
+
+        // Encrypt response
+        return encryptionProvider.encryptResponse(exchangeResponse, eciesEncryption);
     }
 
     /**
@@ -217,6 +226,7 @@ public class EncryptedDataExchangeController {
         byte[] requestData = eciesEncryption.getRequestObject();
 
         if (eciesEncryption.getContext() == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -227,12 +237,12 @@ public class EncryptedDataExchangeController {
                 authHeader
         );
 
-        if (auth != null && auth.getUserId() != null) {
-            // Encrypt response - return the same data as in request
-            return encryptionProvider.encryptResponse(requestData, eciesEncryption);
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getUserId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
+        // Encrypt response - return the same data as in request
+        return encryptionProvider.encryptResponse(requestData, eciesEncryption);
     }
 
 }

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/AuthenticationController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/AuthenticationController.java
@@ -60,7 +60,7 @@ public class AuthenticationController {
                     + " using factor: " + auth.getSignatureFactors()
             );
         } else {
-            throw new PowerAuthAuthenticationException("Login failed");
+            throw new PowerAuthAuthenticationException();
         }
 
     }
@@ -83,7 +83,7 @@ public class AuthenticationController {
         if (auth != null && auth.getUserId() != null) {
             return new ObjectResponse<>("Hooray! User: " + auth.getUserId());
         } else {
-            throw new PowerAuthAuthenticationException("Login failed");
+            throw new PowerAuthAuthenticationException();
         }
 
     }

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/AuthenticationController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/AuthenticationController.java
@@ -60,7 +60,7 @@ public class AuthenticationController {
                     + " using factor: " + auth.getSignatureFactors()
             );
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
     }
@@ -83,7 +83,7 @@ public class AuthenticationController {
         if (auth != null && auth.getUserId() != null) {
             return new ObjectResponse<>("Hooray! User: " + auth.getUserId());
         } else {
-            throw new PowerAuthAuthenticationException();
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
     }

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/AuthenticationController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/AuthenticationController.java
@@ -22,6 +22,7 @@ package io.getlime.security.powerauth.app.rest.api.spring.controller;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,17 +53,15 @@ public class AuthenticationController {
         // ##EXAMPLE: ... or you can grab a user ID like this and use it for querying back-end:
         // ##EXAMPLE: String userId = apiAuthentication.getUserId();
 
-        if (auth != null && auth.getUserId() != null) {
-            return new ObjectResponse<>("Hooray! "
-                    + " User: " + auth.getUserId()
-                    + " (activation: " + auth.getActivationId() + ")"
-                    + " successfully verified via app with ID: " + auth.getApplicationId()
-                    + " using factor: " + auth.getSignatureFactors()
-            );
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getUserId() == null) {
+            throw new PowerAuthSignatureInvalidException();
         }
-
+        return new ObjectResponse<>("Hooray! "
+                + " User: " + auth.getUserId()
+                + " (activation: " + auth.getActivationId() + ")"
+                + " successfully verified via app with ID: " + auth.getApplicationId()
+                + " using factor: " + auth.getSignatureFactors()
+        );
     }
 
     /**
@@ -80,12 +79,10 @@ public class AuthenticationController {
         // ##EXAMPLE: ... or you can grab a user ID like this and use it for querying back-end:
         // ##EXAMPLE: String userId = apiAuthentication.getUserId();
 
-        if (auth != null && auth.getUserId() != null) {
-            return new ObjectResponse<>("Hooray! User: " + auth.getUserId());
-        } else {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+        if (auth == null || auth.getUserId() == null) {
+            throw new PowerAuthSignatureInvalidException();
         }
-
+        return new ObjectResponse<>("Hooray! User: " + auth.getUserId());
     }
 
 }

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v2/CustomActivationController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v2/CustomActivationController.java
@@ -158,7 +158,7 @@ public class CustomActivationController {
             return powerAuthApiResponse;
 
         } catch (Exception ex) {
-            logger.warn(ex.getMessage(), ex);
+            logger.warn("Create activation failed, error: {}", ex.getMessage());
             throw new PowerAuthActivationException();
         }
 

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v2/CustomActivationController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v2/CustomActivationController.java
@@ -95,12 +95,14 @@ public class CustomActivationController {
 
             // Check if there is any user provider to be autowired
             if (activationProvider == null) {
+                logger.warn("Activation provider is missing");
                 throw new PowerAuthActivationException();
             }
 
             // Prepare an encryptor
             final PowerAuthNonPersonalizedEncryptor encryptor = encryptorFactory.buildNonPersonalizedEncryptor(encryptedRequest);
             if (encryptor == null) {
+                logger.warn("Encryptor is not available");
                 throw new PowerAuthActivationException();
             }
 
@@ -108,6 +110,7 @@ public class CustomActivationController {
             ActivationCreateCustomRequest request = encryptor.decrypt(encryptedRequest, ActivationCreateCustomRequest.class);
 
             if (request == null) {
+                logger.warn("Invalid request in activation create");
                 throw new PowerAuthActivationException();
             }
 
@@ -117,6 +120,7 @@ public class CustomActivationController {
 
             // If no user was found or user ID is invalid, return error
             if (userId == null || userId.equals("") || userId.length() > 255) {
+                logger.warn("User ID is invalid: {}", userId);
                 throw new PowerAuthActivationException();
             }
 
@@ -159,7 +163,7 @@ public class CustomActivationController {
 
         } catch (Exception ex) {
             logger.warn("Create activation failed, error: {}", ex.getMessage());
-            throw new PowerAuthActivationException();
+            throw new PowerAuthActivationException(ex);
         }
 
     }

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v2/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v2/EncryptedDataExchangeController.java
@@ -70,12 +70,14 @@ public class EncryptedDataExchangeController {
     @RequestMapping(value = "exchange", method = RequestMethod.POST)
     public ObjectResponse<NonPersonalizedEncryptedPayloadModel> exchange(@RequestBody ObjectRequest<NonPersonalizedEncryptedPayloadModel> request) throws PowerAuthEncryptionException {
         if (request == null) {
+            logger.warn("Invalid request in exchange method");
             throw new PowerAuthEncryptionException();
         }
 
         // Prepare an encryptor
         final PowerAuthNonPersonalizedEncryptor encryptor = encryptorFactory.buildNonPersonalizedEncryptor(request);
         if (encryptor == null) {
+            logger.warn("Encryptor is not available");
             throw new PowerAuthEncryptionException();
         }
 
@@ -85,10 +87,11 @@ public class EncryptedDataExchangeController {
             requestDataBytes = encryptor.decrypt(request);
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
             logger.warn("Encryption failed, error: {}", ex.getMessage());
-            throw new PowerAuthEncryptionException();
+            throw new PowerAuthEncryptionException(ex);
         }
 
         if (requestDataBytes == null) {
+            logger.warn("Invalid request data in exchange method");
             throw new PowerAuthEncryptionException();
         }
 
@@ -103,7 +106,7 @@ public class EncryptedDataExchangeController {
             encryptedResponse = encryptor.encrypt(responseData.getBytes());
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
             logger.warn("Encryption failed, error: {}", ex.getMessage());
-            throw new PowerAuthEncryptionException();
+            throw new PowerAuthEncryptionException(ex);
         }
 
         return encryptedResponse;

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v2/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v2/EncryptedDataExchangeController.java
@@ -84,7 +84,7 @@ public class EncryptedDataExchangeController {
         try {
             requestDataBytes = encryptor.decrypt(request);
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
-            logger.warn(ex.getMessage(), ex);
+            logger.warn("Encryption failed, error: {}", ex.getMessage());
             throw new PowerAuthEncryptionException();
         }
 
@@ -102,7 +102,7 @@ public class EncryptedDataExchangeController {
         try {
             encryptedResponse = encryptor.encrypt(responseData.getBytes());
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException ex) {
-            logger.warn(ex.getMessage(), ex);
+            logger.warn("Encryption failed, error: {}", ex.getMessage());
             throw new PowerAuthEncryptionException();
         }
 

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v3/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v3/EncryptedDataExchangeController.java
@@ -26,9 +26,12 @@ import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAu
 import io.getlime.security.powerauth.rest.api.base.encryption.EciesEncryptionContext;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthEncryptionException;
+import io.getlime.security.powerauth.rest.api.base.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.spring.annotation.EncryptedRequestBody;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuthEncryption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,6 +50,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/exchange")
 public class EncryptedDataExchangeController {
 
+    private final static Logger logger = LoggerFactory.getLogger(EncryptedDataExchangeController.class);
+
     /**
      * Sample encrypted data exchange in application scope.
      *
@@ -61,6 +66,7 @@ public class EncryptedDataExchangeController {
                                              EciesEncryptionContext eciesContext) throws PowerAuthEncryptionException {
 
         if (eciesContext == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -82,6 +88,7 @@ public class EncryptedDataExchangeController {
                                             EciesEncryptionContext eciesContext) throws PowerAuthEncryptionException {
 
         if (eciesContext == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -107,10 +114,12 @@ public class EncryptedDataExchangeController {
                                                                 PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
         if (auth == null || auth.getUserId() == null) {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
 
         if (eciesContext == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -136,10 +145,12 @@ public class EncryptedDataExchangeController {
                                                                        PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
         if (auth == null || auth.getUserId() == null) {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
 
         if (eciesContext == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 
@@ -165,10 +176,12 @@ public class EncryptedDataExchangeController {
                                                                PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
         if (auth == null || auth.getUserId() == null) {
-            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
         }
 
         if (eciesContext == null) {
+            logger.debug("Encryption failed");
             throw new PowerAuthEncryptionException();
         }
 

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v3/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v3/EncryptedDataExchangeController.java
@@ -107,11 +107,11 @@ public class EncryptedDataExchangeController {
                                                                 PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
         if (auth == null || auth.getUserId() == null) {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Return a slightly different String containing original data in response
@@ -136,11 +136,11 @@ public class EncryptedDataExchangeController {
                                                                        PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
         if (auth == null || auth.getUserId() == null) {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Return a slightly different String containing original data in response
@@ -165,11 +165,11 @@ public class EncryptedDataExchangeController {
                                                                PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
         if (auth == null || auth.getUserId() == null) {
-            throw new PowerAuthAuthenticationException("Signature validation failed");
+            throw new PowerAuthAuthenticationException("POWER_AUTH_SIGNATURE_INVALID");
         }
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Return data back for verification

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v3/EncryptedDataExchangeController.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/controller/v3/EncryptedDataExchangeController.java
@@ -61,7 +61,7 @@ public class EncryptedDataExchangeController {
                                              EciesEncryptionContext eciesContext) throws PowerAuthEncryptionException {
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Return a slightly different String containing original data in response
@@ -82,7 +82,7 @@ public class EncryptedDataExchangeController {
                                             EciesEncryptionContext eciesContext) throws PowerAuthEncryptionException {
 
         if (eciesContext == null) {
-            throw new PowerAuthEncryptionException("Decryption failed");
+            throw new PowerAuthEncryptionException();
         }
 
         // Return a slightly different String containing original data in response

--- a/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/errorhandling/DefaultExceptionHandler.java
+++ b/powerauth-restful-server-spring/src/main/java/io/getlime/security/powerauth/app/rest/api/spring/errorhandling/DefaultExceptionHandler.java
@@ -48,7 +48,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(value = Exception.class)
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleException(Exception exception) {
-        logger.error(exception.getMessage(), exception);
+        logger.warn(exception.getMessage(), exception);
         return new ErrorResponse(Error.Code.ERROR_GENERIC, exception);
     }
 


### PR DESCRIPTION
I unified the logging and error handling in restful-integration:
- Use `ex` instead of `e` in caught exceptions
- Use `warn` level for error messages instead of the `error` level
- Do not log stack traces, log error messages to avoid flooding logs of application which uses restful-integration
- Do not provide additional details in thrown exceptions, log these details instead
- Use `{}` instead of string concatenation
- Always log warnings when an exception is caught to allow easier debugging

I also fixed 2 cases when signature type convertor needed to be updated to new logic.