### PR TITLE
Fix #304: Exclude log4j-api dependency

### DIFF
--- a/powerauth-restful-security-spring-annotation/pom.xml
+++ b/powerauth-restful-security-spring-annotation/pom.xml
@@ -42,6 +42,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/powerauth-restful-security-spring/pom.xml
+++ b/powerauth-restful-security-spring/pom.xml
@@ -47,6 +47,12 @@
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-rest-client-spring</artifactId>
             <version>1.2.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
This change should resolve any future questions about the Log4J dependencies included in Spring logging.