### PR TITLE
Fix #416: Do not use nonce for older protocols

### DIFF
--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/EciesEncryptedResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/EciesEncryptedResponse.java
@@ -26,7 +26,6 @@ package io.getlime.security.powerauth.rest.api.model.response;
  */
 public class EciesEncryptedResponse {
 
-    private String ephemeralPublicKey;
     private String encryptedData;
     private String mac;
     private String nonce;
@@ -42,32 +41,14 @@ public class EciesEncryptedResponse {
      * Constructor with Base64 encoded encrypted data and MAC of key and data.
      * @param encryptedData Encrypted data.
      * @param mac MAC of key and data.
-     * @param ephemeralPublicKey Ephemeral public key.
      * @param nonce ECIES nonce.
      * @param timestamp Unix timestamp in milliseconds.
      */
-    public EciesEncryptedResponse(String encryptedData, String mac, String ephemeralPublicKey, String nonce, Long timestamp) {
+    public EciesEncryptedResponse(String encryptedData, String mac, String nonce, Long timestamp) {
         this.encryptedData = encryptedData;
         this.mac = mac;
-        this.ephemeralPublicKey = ephemeralPublicKey;
         this.nonce = nonce;
         this.timestamp = timestamp;
-    }
-
-    /**
-     * Get ephemeral public key.
-     * @return Ephemeral public key.
-     */
-    public String getEphemeralPublicKey() {
-        return ephemeralPublicKey;
-    }
-
-    /**
-     * Set ephemeral public key.
-     * @param ephemeralPublicKey Ephemeral public key.
-     */
-    public void setEphemeralPublicKey(String ephemeralPublicKey) {
-        this.ephemeralPublicKey = ephemeralPublicKey;
     }
 
     /**

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/EncryptionResponseBodyAdvice.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/EncryptionResponseBodyAdvice.java
@@ -136,11 +136,6 @@ public class EncryptionResponseBodyAdvice implements ResponseBodyAdvice<Object> 
                 nonce = Base64.getEncoder().encodeToString(nonceBytes);
                 timestamp = new Date().getTime();
                 eciesParameters = EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
-            } else if ("3.1".equals(version)) {
-                final byte[] nonceBytes = new KeyGenerator().generateRandomBytes(16);
-                nonce = Base64.getEncoder().encodeToString(nonceBytes);
-                timestamp = null;
-                eciesParameters = EciesParameters.builder().nonce(nonceBytes).build();
             } else {
                 nonce = null;
                 timestamp = null;
@@ -150,11 +145,9 @@ public class EncryptionResponseBodyAdvice implements ResponseBodyAdvice<Object> 
             final EciesPayload payload = eciesEncryptor.encrypt(responseBytes, eciesParameters);
             final String encryptedDataBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getEncryptedData());
             final String macBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getMac());
-            final String ephemeralPublicKey64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getEphemeralPublicKey());
 
             // Return encrypted response with type given by converter class
-            final EciesEncryptedResponse encryptedResponse = new EciesEncryptedResponse(encryptedDataBase64, macBase64, ephemeralPublicKey64,
-                    nonce, timestamp);
+            final EciesEncryptedResponse encryptedResponse = new EciesEncryptedResponse(encryptedDataBase64, macBase64, nonce, timestamp);
             if (converterClass.isAssignableFrom(MappingJackson2HttpMessageConverter.class)) {
                 // Object conversion is done automatically using MappingJackson2HttpMessageConverter
                 return encryptedResponse;

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProviderBase.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProviderBase.java
@@ -249,7 +249,7 @@ public abstract class PowerAuthEncryptionProviderBase {
             final byte[] associatedData;
             final String version = eciesEncryption.getContext().getVersion();
             final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
-            final String nonceResponse = Base64.getEncoder().encodeToString(nonceBytesResponse);
+            final String nonceResponse = nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null;
             final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
             switch (eciesScope) {
                 case ACTIVATION_SCOPE -> {
@@ -286,8 +286,7 @@ public abstract class PowerAuthEncryptionProviderBase {
             final EciesPayload payload = encryptor.encrypt(responseData, parametersResponse);
             final String encryptedDataBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getEncryptedData());
             final String macBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getMac());
-            final String ephemeralPublicKey64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getEphemeralPublicKey());
-            return new EciesEncryptedResponse(encryptedDataBase64, macBase64, ephemeralPublicKey64, nonceResponse, timestampResponse);
+            return new EciesEncryptedResponse(encryptedDataBase64, macBase64, nonceResponse, timestampResponse);
         } catch (Exception ex) {
             logger.debug("Response encryption failed, error: " + ex.getMessage(), ex);
             return null;

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/ActivationService.java
@@ -247,7 +247,7 @@ public class ActivationService {
                     }
 
                     // Prepare and return encrypted response
-                    return prepareEncryptedResponse(response.getEphemeralPublicKey(), response.getEncryptedData(), response.getMac(),
+                    return prepareEncryptedResponse(response.getEncryptedData(), response.getMac(),
                             response.getNonce(), response.getTimestamp(), processedCustomAttributes, userInfo);
                 }
 
@@ -360,7 +360,7 @@ public class ActivationService {
                     }
 
                     // Prepare encrypted activation data
-                    return prepareEncryptedResponse(response.getEphemeralPublicKey(), response.getEncryptedData(), response.getMac(),
+                    return prepareEncryptedResponse(response.getEncryptedData(), response.getMac(),
                             response.getNonce(), response.getTimestamp(), processedCustomAttributes, userInfo);
                 }
 
@@ -470,7 +470,7 @@ public class ActivationService {
                     }
 
                     // Prepare and return encrypted response
-                    return prepareEncryptedResponse(response.getEphemeralPublicKey(), response.getEncryptedData(), response.getMac(),
+                    return prepareEncryptedResponse(response.getEncryptedData(), response.getMac(),
                             response.getNonce(), response.getTimestamp(), processedCustomAttributes, userInfo);
                 }
                 default -> {
@@ -594,18 +594,16 @@ public class ActivationService {
     /**
      * Prepare payload for the encrypted response.
      *
-     * @param ephemeralPublicKey Ephemeral public key for ECIES.
      * @param encryptedData Encrypted data.
      * @param mac MAC code of the encrypted data.
      * @param processedCustomAttributes Custom attributes to be returned.
      * @return Encrypted response object.
      */
-    private ActivationLayer1Response prepareEncryptedResponse(String ephemeralPublicKey, String encryptedData, String mac, String nonce, Long timestmap, Map<String, Object> processedCustomAttributes, Map<String, Object> userInfo) {
+    private ActivationLayer1Response prepareEncryptedResponse(String encryptedData, String mac, String nonce, Long timestmap, Map<String, Object> processedCustomAttributes, Map<String, Object> userInfo) {
         // Prepare encrypted response object for layer 2
         final EciesEncryptedResponse encryptedResponseL2 = new EciesEncryptedResponse();
         encryptedResponseL2.setEncryptedData(encryptedData);
         encryptedResponseL2.setMac(mac);
-        encryptedResponseL2.setEphemeralPublicKey(ephemeralPublicKey);
         encryptedResponseL2.setNonce(nonce);
         encryptedResponseL2.setTimestamp(timestmap);
 

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/RecoveryService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/RecoveryService.java
@@ -100,7 +100,7 @@ public class RecoveryService {
                 logger.warn("PowerAuth confirm recovery failed because of invalid activation ID in response");
                 throw new PowerAuthInvalidRequestException();
             }
-            return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac(), paResponse.getEphemeralPublicKey(),
+            return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac(),
                     paResponse.getNonce(), paResponse.getTimestamp());
         } catch (Exception ex) {
             logger.warn("PowerAuth confirm recovery failed, error: {}", ex.getMessage());

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/SecureVaultService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/SecureVaultService.java
@@ -137,7 +137,7 @@ public class SecureVaultService {
             }
 
             return new EciesEncryptedResponse(paResponse.getEncryptedData(), paResponse.getMac(),
-                    paResponse.getEphemeralPublicKey(), paResponse.getNonce(), paResponse.getTimestamp());
+                    paResponse.getNonce(), paResponse.getTimestamp());
         } catch (PowerAuthAuthenticationException ex) {
             throw ex;
         } catch (Exception ex) {

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/TokenService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/TokenService.java
@@ -126,7 +126,6 @@ public class TokenService {
             final EciesEncryptedResponse response = new EciesEncryptedResponse();
             response.setMac(token.getMac());
             response.setEncryptedData(token.getEncryptedData());
-            response.setEphemeralPublicKey(token.getEphemeralPublicKey());
             response.setNonce(token.getNonce());
             response.setMac(token.getMac());
             return response;

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/UpgradeService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/UpgradeService.java
@@ -120,7 +120,6 @@ public class UpgradeService {
             final EciesEncryptedResponse response = new EciesEncryptedResponse();
             response.setMac(upgradeResponse.getMac());
             response.setEncryptedData(upgradeResponse.getEncryptedData());
-            response.setEphemeralPublicKey(upgradeResponse.getEphemeralPublicKey());
             response.setNonce(upgradeResponse.getNonce());
             response.setTimestamp(upgradeResponse.getTimestamp());
             return response;


### PR DESCRIPTION
This PR fixes problem where requests in protocol version 3.1 were responded with ECIES encryption configured to use not-supported response nonce. On top of that, the change removes "ephemeralPublicKey" from all encrypted responses.