### PR TITLE
Fix #418: Use proper nonce to encrypt response for V3.1

### DIFF
--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/PowerAuthEciesEncryption.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/PowerAuthEciesEncryption.java
@@ -21,6 +21,8 @@ package io.getlime.security.powerauth.rest.api.spring.encryption;
 
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesPayload;
 
 /**
  * Class used for storing data used during ECIES decryption and encryption. A reference to an initialized ECIES decryptor
@@ -35,6 +37,7 @@ public class PowerAuthEciesEncryption {
     private final EciesEncryptionContext context;
     private EciesDecryptor eciesDecryptor;
     private EciesEncryptor eciesEncryptor;
+    private EciesParameters requestParameters;
     private byte[] encryptedRequest;
     private byte[] decryptedRequest;
     private byte[] associatedData;
@@ -153,4 +156,19 @@ public class PowerAuthEciesEncryption {
         this.requestObject = requestObject;
     }
 
+    /**
+     * Set ECIES parameters for request decryption.
+     * @param requestParameters ECIES parameters.
+     */
+    public void setRequestParameters(EciesParameters requestParameters) {
+        this.requestParameters = requestParameters;
+    }
+
+    /**
+     * Get ECIES parameters for request decryption.
+     * @return ECIES parameters.
+     */
+    public EciesParameters getRequestParameters() {
+        return requestParameters;
+    }
 }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/EncryptionResponseBodyAdvice.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/EncryptionResponseBodyAdvice.java
@@ -139,7 +139,7 @@ public class EncryptionResponseBodyAdvice implements ResponseBodyAdvice<Object> 
             } else {
                 nonce = null;
                 timestamp = null;
-                eciesParameters = EciesParameters.builder().build();
+                eciesParameters = eciesEncryption.getRequestParameters();
             }
 
             final EciesPayload payload = eciesEncryptor.encrypt(responseBytes, eciesParameters);

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/model/ActivationContext.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/model/ActivationContext.java
@@ -46,6 +46,9 @@ public class ActivationContext {
     private String deviceInfo;
     private String extras;
 
+    /**
+     * Activation context constructor.
+     */
     public ActivationContext() {
         this.activationFlags = new ArrayList<>();
     }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProviderBase.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProviderBase.java
@@ -70,8 +70,6 @@ public abstract class PowerAuthEncryptionProviderBase {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final EciesFactory eciesFactory = new EciesFactory();
-    // TODO: UNUSED
-    //private final KeyGenerator keyGenerator = new KeyGenerator();
 
     /**
      * Get ECIES decryptor parameters from PowerAuth server.
@@ -172,6 +170,7 @@ public abstract class PowerAuthEncryptionProviderBase {
 
             final String applicationKey = eciesEncryption.getContext().getApplicationKey();
             final PowerAuthEciesDecryptorParameters decryptorParameters;
+            final PowerAuthEciesDecryptorParameters encryptorParameters;
             // Obtain ECIES decryptor parameters from PowerAuth server
             final byte[] associatedData;
             switch (eciesScope) {
@@ -228,75 +227,7 @@ public abstract class PowerAuthEncryptionProviderBase {
         }
         return eciesEncryption;
     }
-
-// TODO: UNUSED
-
-//    /**
-//     * Encrypt response using ECIES.
-//     *
-//     * @param responseObject  Response object which should be encrypted.
-//     * @param eciesEncryption PowerAuth encryption object.
-//     * @return ECIES encrypted response.
-//     */
-//    public @Nullable
-//    EciesEncryptedResponse encryptResponse(@Nonnull Object responseObject, @Nonnull PowerAuthEciesEncryption eciesEncryption) {
-//        try {
-//            final EciesEncryptionContext encryptionContext = eciesEncryption.getContext();
-//            final EciesScope eciesScope = encryptionContext.getEciesScope();
-//
-//            final String applicationKey = eciesEncryption.getContext().getApplicationKey();
-//            final String ephemeralPublicKey = eciesEncryption.getContext().getEphemeralPublicKey();
-//            final byte[] ephemeralPublicKeyBytes = Base64.getDecoder().decode(ephemeralPublicKey);
-//
-//            final PowerAuthEciesDecryptorParameters encryptorParameters;
-//            // Obtain ECIES decryptor parameters from PowerAuth server
-//            final byte[] associatedData;
-//            final String version = eciesEncryption.getContext().getVersion();
-//            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
-//            final String nonceResponse = nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null;
-//            final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
-//            switch (eciesScope) {
-//                case ACTIVATION_SCOPE -> {
-//                    final String activationId = eciesEncryption.getContext().getActivationId();
-//                    if (activationId == null) {
-//                        logger.warn("Activation ID is required in ECIES activation scope");
-//                        throw new PowerAuthEncryptionException();
-//                    }
-//                    encryptorParameters = getEciesDecryptorParameters(activationId, applicationKey, ephemeralPublicKey, encryptionContext.getVersion(), nonceResponse, timestampResponse);
-//                    associatedData = "3.2".equals(encryptionContext.getVersion()) ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, encryptionContext.getVersion(), applicationKey, activationId) : null;
-//                }
-//                case APPLICATION_SCOPE -> {
-//                    encryptorParameters = getEciesDecryptorParameters(null, applicationKey, ephemeralPublicKey, encryptionContext.getVersion(), nonceResponse, timestampResponse);
-//                    associatedData = "3.2".equals(encryptionContext.getVersion()) ? EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, encryptionContext.getVersion(), applicationKey, null) : null;
-//                }
-//                default -> {
-//                    logger.warn("Unsupported ECIES scope: {}", eciesScope);
-//                    throw new PowerAuthEncryptionException();
-//                }
-//            }
-//
-//            // Prepare envelope key and sharedInfo2 parameter for encryptor
-//            final byte[] secretKey = Base64.getDecoder().decode(encryptorParameters.secretKey());
-//            final EciesEnvelopeKey envelopeKey = new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
-//            final byte[] sharedInfo2 = Base64.getDecoder().decode(encryptorParameters.sharedInfo2());
-//
-//            final byte[] responseData = serializeResponseData(responseObject);
-//            // Encrypt response using encryptor and return ECIES cryptogram
-//            final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(associatedData).timestamp(timestampResponse).build();
-//            final EciesEncryptor encryptor = eciesFactory.getEciesEncryptor(envelopeKey, sharedInfo2);
-//            // Store ECIES encryptor
-//            eciesEncryption.setEciesEncryptor(encryptor);
-//
-//            final EciesPayload payload = encryptor.encrypt(responseData, parametersResponse);
-//            final String encryptedDataBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getEncryptedData());
-//            final String macBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getMac());
-//            return new EciesEncryptedResponse(encryptedDataBase64, macBase64, nonceResponse, timestampResponse);
-//        } catch (Exception ex) {
-//            logger.debug("Response encryption failed, error: " + ex.getMessage(), ex);
-//            return null;
-//        }
-//    }
-
+    
     /**
      * Convert byte[] request data to Object with given type.
      *

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProviderBase.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProviderBase.java
@@ -70,7 +70,8 @@ public abstract class PowerAuthEncryptionProviderBase {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final EciesFactory eciesFactory = new EciesFactory();
-    private final KeyGenerator keyGenerator = new KeyGenerator();
+    // TODO: UNUSED
+    //private final KeyGenerator keyGenerator = new KeyGenerator();
 
     /**
      * Get ECIES decryptor parameters from PowerAuth server.
@@ -212,6 +213,7 @@ public abstract class PowerAuthEncryptionProviderBase {
             eciesEncryption.setEncryptedRequest(encryptedDataBytes);
             eciesEncryption.setDecryptedRequest(decryptedData);
             eciesEncryption.setAssociatedData(associatedData);
+            eciesEncryption.setRequestParameters(parameters);
             // Set the request object only in case when request data is sent
             if (decryptedData.length != 0) {
                 eciesEncryption.setRequestObject(deserializeRequestData(decryptedData, requestType));
@@ -227,71 +229,73 @@ public abstract class PowerAuthEncryptionProviderBase {
         return eciesEncryption;
     }
 
-    /**
-     * Encrypt response using ECIES.
-     *
-     * @param responseObject  Response object which should be encrypted.
-     * @param eciesEncryption PowerAuth encryption object.
-     * @return ECIES encrypted response.
-     */
-    public @Nullable
-    EciesEncryptedResponse encryptResponse(@Nonnull Object responseObject, @Nonnull PowerAuthEciesEncryption eciesEncryption) {
-        try {
-            final EciesEncryptionContext encryptionContext = eciesEncryption.getContext();
-            final EciesScope eciesScope = encryptionContext.getEciesScope();
+// TODO: UNUSED
 
-            final String applicationKey = eciesEncryption.getContext().getApplicationKey();
-            final String ephemeralPublicKey = eciesEncryption.getContext().getEphemeralPublicKey();
-            final byte[] ephemeralPublicKeyBytes = Base64.getDecoder().decode(ephemeralPublicKey);
-
-            final PowerAuthEciesDecryptorParameters encryptorParameters;
-            // Obtain ECIES decryptor parameters from PowerAuth server
-            final byte[] associatedData;
-            final String version = eciesEncryption.getContext().getVersion();
-            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
-            final String nonceResponse = nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null;
-            final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
-            switch (eciesScope) {
-                case ACTIVATION_SCOPE -> {
-                    final String activationId = eciesEncryption.getContext().getActivationId();
-                    if (activationId == null) {
-                        logger.warn("Activation ID is required in ECIES activation scope");
-                        throw new PowerAuthEncryptionException();
-                    }
-                    encryptorParameters = getEciesDecryptorParameters(activationId, applicationKey, ephemeralPublicKey, encryptionContext.getVersion(), nonceResponse, timestampResponse);
-                    associatedData = "3.2".equals(encryptionContext.getVersion()) ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, encryptionContext.getVersion(), applicationKey, activationId) : null;
-                }
-                case APPLICATION_SCOPE -> {
-                    encryptorParameters = getEciesDecryptorParameters(null, applicationKey, ephemeralPublicKey, encryptionContext.getVersion(), nonceResponse, timestampResponse);
-                    associatedData = "3.2".equals(encryptionContext.getVersion()) ? EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, encryptionContext.getVersion(), applicationKey, null) : null;
-                }
-                default -> {
-                    logger.warn("Unsupported ECIES scope: {}", eciesScope);
-                    throw new PowerAuthEncryptionException();
-                }
-            }
-
-            // Prepare envelope key and sharedInfo2 parameter for encryptor
-            final byte[] secretKey = Base64.getDecoder().decode(encryptorParameters.secretKey());
-            final EciesEnvelopeKey envelopeKey = new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
-            final byte[] sharedInfo2 = Base64.getDecoder().decode(encryptorParameters.sharedInfo2());
-
-            final byte[] responseData = serializeResponseData(responseObject);
-            // Encrypt response using encryptor and return ECIES cryptogram
-            final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(associatedData).timestamp(timestampResponse).build();
-            final EciesEncryptor encryptor = eciesFactory.getEciesEncryptor(envelopeKey, sharedInfo2);
-            // Store ECIES encryptor
-            eciesEncryption.setEciesEncryptor(encryptor);
-
-            final EciesPayload payload = encryptor.encrypt(responseData, parametersResponse);
-            final String encryptedDataBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getEncryptedData());
-            final String macBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getMac());
-            return new EciesEncryptedResponse(encryptedDataBase64, macBase64, nonceResponse, timestampResponse);
-        } catch (Exception ex) {
-            logger.debug("Response encryption failed, error: " + ex.getMessage(), ex);
-            return null;
-        }
-    }
+//    /**
+//     * Encrypt response using ECIES.
+//     *
+//     * @param responseObject  Response object which should be encrypted.
+//     * @param eciesEncryption PowerAuth encryption object.
+//     * @return ECIES encrypted response.
+//     */
+//    public @Nullable
+//    EciesEncryptedResponse encryptResponse(@Nonnull Object responseObject, @Nonnull PowerAuthEciesEncryption eciesEncryption) {
+//        try {
+//            final EciesEncryptionContext encryptionContext = eciesEncryption.getContext();
+//            final EciesScope eciesScope = encryptionContext.getEciesScope();
+//
+//            final String applicationKey = eciesEncryption.getContext().getApplicationKey();
+//            final String ephemeralPublicKey = eciesEncryption.getContext().getEphemeralPublicKey();
+//            final byte[] ephemeralPublicKeyBytes = Base64.getDecoder().decode(ephemeralPublicKey);
+//
+//            final PowerAuthEciesDecryptorParameters encryptorParameters;
+//            // Obtain ECIES decryptor parameters from PowerAuth server
+//            final byte[] associatedData;
+//            final String version = eciesEncryption.getContext().getVersion();
+//            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
+//            final String nonceResponse = nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null;
+//            final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
+//            switch (eciesScope) {
+//                case ACTIVATION_SCOPE -> {
+//                    final String activationId = eciesEncryption.getContext().getActivationId();
+//                    if (activationId == null) {
+//                        logger.warn("Activation ID is required in ECIES activation scope");
+//                        throw new PowerAuthEncryptionException();
+//                    }
+//                    encryptorParameters = getEciesDecryptorParameters(activationId, applicationKey, ephemeralPublicKey, encryptionContext.getVersion(), nonceResponse, timestampResponse);
+//                    associatedData = "3.2".equals(encryptionContext.getVersion()) ? EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, encryptionContext.getVersion(), applicationKey, activationId) : null;
+//                }
+//                case APPLICATION_SCOPE -> {
+//                    encryptorParameters = getEciesDecryptorParameters(null, applicationKey, ephemeralPublicKey, encryptionContext.getVersion(), nonceResponse, timestampResponse);
+//                    associatedData = "3.2".equals(encryptionContext.getVersion()) ? EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, encryptionContext.getVersion(), applicationKey, null) : null;
+//                }
+//                default -> {
+//                    logger.warn("Unsupported ECIES scope: {}", eciesScope);
+//                    throw new PowerAuthEncryptionException();
+//                }
+//            }
+//
+//            // Prepare envelope key and sharedInfo2 parameter for encryptor
+//            final byte[] secretKey = Base64.getDecoder().decode(encryptorParameters.secretKey());
+//            final EciesEnvelopeKey envelopeKey = new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
+//            final byte[] sharedInfo2 = Base64.getDecoder().decode(encryptorParameters.sharedInfo2());
+//
+//            final byte[] responseData = serializeResponseData(responseObject);
+//            // Encrypt response using encryptor and return ECIES cryptogram
+//            final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(associatedData).timestamp(timestampResponse).build();
+//            final EciesEncryptor encryptor = eciesFactory.getEciesEncryptor(envelopeKey, sharedInfo2);
+//            // Store ECIES encryptor
+//            eciesEncryption.setEciesEncryptor(encryptor);
+//
+//            final EciesPayload payload = encryptor.encrypt(responseData, parametersResponse);
+//            final String encryptedDataBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getEncryptedData());
+//            final String macBase64 = Base64.getEncoder().encodeToString(payload.getCryptogram().getMac());
+//            return new EciesEncryptedResponse(encryptedDataBase64, macBase64, nonceResponse, timestampResponse);
+//        } catch (Exception ex) {
+//            logger.debug("Response encryption failed, error: " + ex.getMessage(), ex);
+//            return null;
+//        }
+//    }
 
     /**
      * Convert byte[] request data to Object with given type.

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/UserInfoService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/UserInfoService.java
@@ -44,6 +44,10 @@ public class UserInfoService {
     private UserInfoProvider userInfoProvider;
     private final PowerAuthClient powerAuthClient;
 
+    /**
+     * Service constructor.
+     * @param powerAuthClient PowerAuthClient instance.
+     */
     @Autowired
     public UserInfoService(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;


### PR DESCRIPTION
This PR fixes proper usage of nonce while encrypting responses for protocol V3.1. Also I fixed several javadoc warnings.

Note that there's one TODO about unused function, but I don't know whether this is used somehow by the clients. It's just unused by the library itself.