### PR TITLE
Fix #486: Allow renaming activation via a standard API endpoints

### DIFF
--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/ActivationRenameRequest.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/request/ActivationRenameRequest.java
@@ -1,0 +1,34 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.request;
+
+import lombok.Data;
+
+/**
+ * Request to change activation name.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Data
+public class ActivationRenameRequest {
+
+    private String activationName;
+
+}

--- a/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/ActivationDetailResponse.java
+++ b/powerauth-restful-model/src/main/java/io/getlime/security/powerauth/rest/api/model/response/ActivationDetailResponse.java
@@ -1,0 +1,35 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.model.response;
+
+import lombok.Data;
+
+/**
+ * Response object with activation detail.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Data
+public class ActivationDetailResponse {
+
+    private String activationId;
+    private String activationName;
+
+}

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/support/PowerAuthEncryptionArgumentResolver.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/annotation/support/PowerAuthEncryptionArgumentResolver.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.MethodParameter;
 import org.springframework.lang.NonNull;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -102,17 +103,17 @@ public class PowerAuthEncryptionArgumentResolver implements HandlerMethodArgumen
     private boolean validateEciesScope(EncryptionContext eciesContext) {
         switch (eciesContext.getEncryptionScope()) {
             case ACTIVATION_SCOPE -> {
-                if (eciesContext.getApplicationKey() == null || eciesContext.getApplicationKey().isEmpty()) {
+                if (!StringUtils.hasLength(eciesContext.getApplicationKey())) {
                     logger.warn("ECIES activation scope is invalid because of missing application key");
                     return false;
                 }
-                if (eciesContext.getActivationId() == null || eciesContext.getActivationId().isEmpty()) {
+                if (!StringUtils.hasLength(eciesContext.getActivationId())) {
                     logger.warn("ECIES activation scope is invalid because of missing activation ID");
                     return false;
                 }
             }
             case APPLICATION_SCOPE -> {
-                if (eciesContext.getApplicationKey() == null || eciesContext.getApplicationKey().isEmpty()) {
+                if (!StringUtils.hasLength(eciesContext.getApplicationKey())) {
                     logger.warn("ECIES application scope is invalid because of missing application key");
                     return false;
                 }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/authentication/impl/PowerAuthTokenAuthenticationImpl.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/authentication/impl/PowerAuthTokenAuthenticationImpl.java
@@ -23,6 +23,8 @@ import io.getlime.security.powerauth.http.PowerAuthHttpHeader;
 import io.getlime.security.powerauth.rest.api.spring.authentication.PowerAuthTokenAuthentication;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 
+import java.io.Serial;
+
 /**
  * Implementation of the {@link PowerAuthTokenAuthentication} interface, with Spring Security objects.
  *
@@ -30,6 +32,8 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
  */
 public class PowerAuthTokenAuthenticationImpl extends AbstractAuthenticationToken implements PowerAuthTokenAuthentication {
 
+    @Serial
+    private static final long serialVersionUID = 1894157176884257385L;
     /**
      * Token ID.
      */

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/EncryptionScope.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/EncryptionScope.java
@@ -49,9 +49,7 @@ public enum EncryptionScope {
             case ACTIVATION_SCOPE -> {
                 return EncryptorScope.ACTIVATION_SCOPE;
             }
-            default -> {
-                throw new IllegalArgumentException("Unsupported scope " + this);
-            }
+            default -> throw new IllegalArgumentException("Unsupported scope " + this);
         }
     }
 }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/PowerAuthEncryptorData.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/encryption/PowerAuthEncryptorData.java
@@ -75,9 +75,7 @@ public class PowerAuthEncryptorData {
             case APPLICATION_SCOPE -> {
                 return EncryptorId.APPLICATION_SCOPE_GENERIC;
             }
-            default -> {
-                throw new IllegalStateException("Unsupported scope " + this);
-            }
+            default -> throw new IllegalStateException("Unsupported scope " + this);
         }
     }
 }

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/PowerAuthRequestFilterBase.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/PowerAuthRequestFilterBase.java
@@ -60,7 +60,7 @@ public class PowerAuthRequestFilterBase {
             // Parse the query parameters
             String queryString = httpRequest.getQueryString();
 
-            if (queryString != null && queryString.length() > 0) {
+            if (queryString != null && !queryString.isEmpty()) {
 
                 // Decode the query string
                 queryString = URLDecoder.decode(queryString, StandardCharsets.UTF_8);

--- a/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/PowerAuthRequestFilterBase.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/io/getlime/security/powerauth/rest/api/spring/filter/PowerAuthRequestFilterBase.java
@@ -26,6 +26,8 @@ import io.getlime.security.powerauth.rest.api.spring.model.PowerAuthRequestBody;
 import io.getlime.security.powerauth.rest.api.spring.model.PowerAuthRequestObjects;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.StringUtils;
+
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -60,7 +62,7 @@ public class PowerAuthRequestFilterBase {
             // Parse the query parameters
             String queryString = httpRequest.getQueryString();
 
-            if (queryString != null && !queryString.isEmpty()) {
+            if (StringUtils.hasLength(queryString)) {
 
                 // Decode the query string
                 queryString = URLDecoder.decode(queryString, StandardCharsets.UTF_8);

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/ActivationController.java
@@ -155,8 +155,11 @@ public class ActivationController {
     }
 
     @PostMapping("detail")
-    @PowerAuthToken
-    @PowerAuthEncryption
+    @PowerAuthToken(signatureType = {
+            PowerAuthSignatureTypes.POSSESSION_BIOMETRY,
+            PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE
+    })
+    @PowerAuthEncryption(scope = EncryptionScope.ACTIVATION_SCOPE)
     public ObjectResponse<ActivationDetailResponse> fetchActivationDetail(PowerAuthApiAuthentication auth) throws PowerAuthSignatureInvalidException, PowerAuthInvalidRequestException, PowerAuthActivationException {
 
         PowerAuthAuthenticationUtil.checkAuthentication(auth);
@@ -172,7 +175,7 @@ public class ActivationController {
             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE,
             PowerAuthSignatureTypes.POSSESSION_BIOMETRY
     })
-    @PowerAuthEncryption
+    @PowerAuthEncryption(scope = EncryptionScope.ACTIVATION_SCOPE)
     public ObjectResponse<ActivationDetailResponse> renameApplication(
             @RequestBody ActivationRenameRequest request,
             PowerAuthApiAuthentication auth) throws PowerAuthSignatureInvalidException, PowerAuthInvalidRequestException, PowerAuthActivationException {

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/ActivationController.java
@@ -169,7 +169,6 @@ public class ActivationController {
         return new ObjectResponse<>(activationDetail);
     }
 
-
     @PostMapping("rename")
     @PowerAuth(resourceId = "/pa/activation/rename", signatureType = {
             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE,

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/RecoveryController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/RecoveryController.java
@@ -20,18 +20,21 @@
 package io.getlime.security.powerauth.rest.api.spring.controller;
 
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
-import io.getlime.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;
-import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthAuthenticationException;
-import io.getlime.security.powerauth.rest.api.spring.exception.authentication.PowerAuthInvalidRequestException;
-import io.getlime.security.powerauth.rest.api.spring.exception.authentication.PowerAuthSignatureInvalidException;
 import io.getlime.security.powerauth.rest.api.model.request.EciesEncryptedRequest;
 import io.getlime.security.powerauth.rest.api.model.response.EciesEncryptedResponse;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
+import io.getlime.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;
+import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.spring.exception.authentication.PowerAuthInvalidRequestException;
 import io.getlime.security.powerauth.rest.api.spring.service.RecoveryService;
+import io.getlime.security.powerauth.rest.api.spring.util.PowerAuthAuthenticationUtil;
 import io.getlime.security.powerauth.rest.api.spring.util.PowerAuthVersionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 
 /**
@@ -65,7 +68,7 @@ public class RecoveryController {
     /**
      * Confirm recovery code.
      * @param request ECIES encrypted request.
-     * @param authentication PowerAuth API authentication object.
+     * @param auth PowerAuth API authentication object.
      * @return ECIES encrypted response.
      * @throws PowerAuthAuthenticationException In case confirm recovery fails.
      */
@@ -74,20 +77,18 @@ public class RecoveryController {
             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE
     })
     public EciesEncryptedResponse confirmRecoveryCode(@RequestBody EciesEncryptedRequest request,
-                                                      PowerAuthApiAuthentication authentication) throws PowerAuthAuthenticationException {
+                                                      PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
         if (request == null) {
             logger.warn("Invalid request object in confirm recovery");
             throw new PowerAuthInvalidRequestException();
         }
-        if (authentication == null || authentication.getActivationContext().getActivationId() == null) {
-            throw new PowerAuthSignatureInvalidException();
-        }
 
-        PowerAuthVersionUtil.checkUnsupportedVersion(authentication.getVersion());
-        PowerAuthVersionUtil.checkMissingRequiredNonce(authentication.getVersion(), request.getNonce());
-        PowerAuthVersionUtil.checkMissingRequiredTimestamp(authentication.getVersion(), request.getTimestamp());
+        PowerAuthAuthenticationUtil.checkAuthentication(auth);
+        PowerAuthVersionUtil.checkUnsupportedVersion(auth.getVersion());
+        PowerAuthVersionUtil.checkMissingRequiredNonce(auth.getVersion(), request.getNonce());
+        PowerAuthVersionUtil.checkMissingRequiredTimestamp(auth.getVersion(), request.getTimestamp());
 
-        return recoveryService.confirmRecoveryCode(request, authentication);
+        return recoveryService.confirmRecoveryCode(request, auth);
     }
 
 }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/controller/SignatureController.java
@@ -21,17 +21,14 @@ package io.getlime.security.powerauth.rest.api.spring.controller;
 
 import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
 import io.getlime.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthAuthenticationException;
-import io.getlime.security.powerauth.rest.api.spring.exception.authentication.PowerAuthSignatureInvalidException;
-import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.getlime.security.powerauth.rest.api.spring.util.PowerAuthAuthenticationUtil;
+import io.getlime.security.powerauth.rest.api.spring.util.PowerAuthVersionUtil;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.getlime.security.powerauth.rest.api.spring.util.PowerAuthVersionUtil;
 
 /**
  * End-point for validating signatures.
@@ -48,8 +45,6 @@ import io.getlime.security.powerauth.rest.api.spring.util.PowerAuthVersionUtil;
 @RequestMapping(value = "/pa/v3/signature")
 public class SignatureController {
 
-    private static final Logger logger = LoggerFactory.getLogger(SignatureController.class);
-
     /**
      * Validate signature by validating any data sent in request to this end-point.
      * @param auth Automatically injected PowerAuth authentication object.
@@ -65,11 +60,7 @@ public class SignatureController {
     })
     public Response validateSignature(PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
 
-        if (auth == null || auth.getActivationContext().getActivationId() == null) {
-            logger.debug("Signature validation failed");
-            throw new PowerAuthSignatureInvalidException();
-        }
-
+        PowerAuthAuthenticationUtil.checkAuthentication(auth);
         PowerAuthVersionUtil.checkUnsupportedVersion(auth.getVersion());
 
         return new Response();

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/service/ActivationService.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 import java.util.*;
@@ -147,7 +148,7 @@ public class ActivationService {
                     // Extract data from request and encryption object
                     final String activationCode = identity.get("code");
 
-                    if (activationCode == null || activationCode.isEmpty()) {
+                    if (!StringUtils.hasText(activationCode)) {
                         logger.warn("Activation code is missing");
                         throw new PowerAuthActivationException();
                     }
@@ -259,7 +260,7 @@ public class ActivationService {
                     final String userId = activationProvider.lookupUserIdForAttributes(identity, context);
 
                     // If no user was found or user ID is invalid, return an error
-                    if (userId == null || userId.isBlank() || userId.length() > 255) {
+                    if (!StringUtils.hasText(userId) || userId.length() > 255) {
                         logger.warn("Invalid user ID: {}", userId);
                         throw new PowerAuthActivationException();
                     }
@@ -363,12 +364,12 @@ public class ActivationService {
                     final String recoveryCode = identity.get("recoveryCode");
                     final String recoveryPuk = identity.get("puk");
 
-                    if (recoveryCode == null || recoveryCode.isEmpty()) {
+                    if (!StringUtils.hasText(recoveryCode)) {
                         logger.warn("Recovery code is missing");
                         throw new PowerAuthActivationException();
                     }
 
-                    if (recoveryPuk == null || recoveryPuk.isEmpty()) {
+                    if (!StringUtils.hasText(recoveryPuk)) {
                         logger.warn("Recovery PUK is missing");
                         throw new PowerAuthActivationException();
                     }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/util/PowerAuthAuthenticationUtil.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/util/PowerAuthAuthenticationUtil.java
@@ -41,7 +41,7 @@ public final class PowerAuthAuthenticationUtil {
 
     /**
      * Check if the authentication represents a valid user.
-     * 
+     *
      * @param auth Authentication object
      * @throws PowerAuthSignatureInvalidException Exception in case the authentication do not represent the user.
      */

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/util/PowerAuthAuthenticationUtil.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/util/PowerAuthAuthenticationUtil.java
@@ -46,7 +46,9 @@ public final class PowerAuthAuthenticationUtil {
      * @throws PowerAuthSignatureInvalidException Exception in case the authentication do not represent the user.
      */
     public static void checkAuthentication(PowerAuthApiAuthentication auth) throws PowerAuthSignatureInvalidException {
-        if (auth == null || auth.getActivationContext().getActivationId() == null) {
+        if (auth == null
+                || auth.getActivationContext() == null
+                || auth.getActivationContext().getActivationId() == null) {
             logger.debug("Signature validation failed");
             throw new PowerAuthSignatureInvalidException();
         }

--- a/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/util/PowerAuthAuthenticationUtil.java
+++ b/powerauth-restful-security-spring/src/main/java/io/getlime/security/powerauth/rest/api/spring/util/PowerAuthAuthenticationUtil.java
@@ -1,0 +1,55 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.rest.api.spring.util;
+
+import io.getlime.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;
+import io.getlime.security.powerauth.rest.api.spring.exception.authentication.PowerAuthSignatureInvalidException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Utility class for common handling of the authentication object.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Slf4j
+public final class PowerAuthAuthenticationUtil {
+
+    /**
+     * Prevent instantiation of utility class.
+     */
+    private PowerAuthAuthenticationUtil() {
+        throw new IllegalStateException("Utility class");
+    }
+
+
+    /**
+     * Check if the authentication represents a valid user.
+     * 
+     * @param auth Authentication object
+     * @throws PowerAuthSignatureInvalidException Exception in case the authentication do not represent the user.
+     */
+    public static void checkAuthentication(PowerAuthApiAuthentication auth) throws PowerAuthSignatureInvalidException {
+        if (auth == null || auth.getActivationContext().getActivationId() == null) {
+            logger.debug("Signature validation failed");
+            throw new PowerAuthSignatureInvalidException();
+        }
+    }
+
+}


### PR DESCRIPTION
Documentation must be changed in `powerauth-crypto` repository. Please review the intended change, and I will then update the docs.